### PR TITLE
Add language settings to YPM

### DIFF
--- a/.claude/commands/ypm-active.md
+++ b/.claude/commands/ypm-active.md
@@ -1,18 +1,21 @@
-`PROJECT_STATUS.md` から最近1週間以内に更新されたアクティブなプロジェクトのみを表示してください。
+<!-- Language Handling: Check ~/.ypm/config.yml for settings.language -->
+<!-- If language is not "en", translate all output to that language -->
 
-**表示内容**:
-- プロジェクト名
-- 概要
-- 現在のブランチ
-- 最終更新日
+Display only active projects updated within the last week from `PROJECT_STATUS.md`.
+
+**Display Content**:
+- Project name
+- Overview
+- Current branch
+- Last update date
 - Phase
-- 実装進捗
-- 次のタスク
+- Implementation progress
+- Next task
 
-**表示形式**:
-アクティブなプロジェクトを更新日時の降順（新しい順）で表示します。
+**Display Format**:
+Display active projects in descending order by update date (newest first).
 
-**追加情報**:
-- アクティブなプロジェクト数の合計
-- 最も進捗しているプロジェクト
-- 最も最近更新されたプロジェクト
+**Additional Information**:
+- Total number of active projects
+- Most progressed project
+- Most recently updated project

--- a/.claude/commands/ypm-help.md
+++ b/.claude/commands/ypm-help.md
@@ -1,105 +1,108 @@
-# YPM (Your Project Manager) - ヘルプ
+<!-- Language Handling: Check ~/.ypm/config.yml for settings.language -->
+<!-- If language is not "en", translate all output to that language -->
 
-## 概要
+# YPM (Your Project Manager) - Help
 
-YPMは `/Users/yamato/Src/` 配下の複数プロジェクトを監視し、進捗を一元管理するシステムです。
+## Overview
+
+YPM monitors multiple projects under your configured directories and provides centralized progress management.
 
 ---
 
-## 利用可能なコマンド
+## Available Commands
 
-### 📊 プロジェクト管理
+### Project Management
 
 #### `/ypm`
-ウェルカムメッセージとよく使うコマンド一覧を表示します。
+Displays the welcome message and common commands list.
 
 #### `/ypm-update`
-全プロジェクトをスキャンして `PROJECT_STATUS.md` を更新します。
-- 各プロジェクトのGit情報を取得
-- CLAUDE.md、README.md、docs/INDEX.md を読み込み
-- 進捗情報（Phase、実装進捗、テスト、ドキュメント）を収集
-- 変更をコミット
+Scans all projects and updates `PROJECT_STATUS.md`.
+- Retrieves Git information for each project
+- Reads CLAUDE.md, README.md, docs/INDEX.md
+- Collects progress information (Phase, implementation progress, tests, documentation)
+- Commits changes
 
 #### `/ypm-next`
-各プロジェクトの「次のタスク」を優先度順に表示します。
-- アクティブなプロジェクト（最近1週間以内に更新）
-- 実装進捗が高いプロジェクト
-- Phase順
+Displays "next tasks" for each project in priority order.
+- Active projects (updated within the last week)
+- Projects with higher implementation progress
+- Phase order
 
 #### `/ypm-active`
-最近1週間以内に更新されたアクティブなプロジェクトのみを表示します。
-- プロジェクト名、概要、ブランチ、最終更新日
-- Phase、実装進捗、次のタスク
+Shows only active projects updated within the last week.
+- Project name, overview, branch, last update date
+- Phase, implementation progress, next task
 
 ---
 
-### 🚀 新規プロジェクト
+### New Projects
 
 #### `/ypm-new`
-新規プロジェクトの立ち上げを支援します。
-- プロジェクト企画（要件定義、技術選定）
-- ディレクトリ作成とGit初期化
-- ドキュメント整備（DDD・TDD・DRY原則）
-- GitHub連携
-- Git Workflow設定
-- 環境設定ファイル整備
+Assists with launching new projects.
+- Project planning (requirements definition, technology selection)
+- Directory creation and Git initialization
+- Documentation setup (DDD/TDD/DRY principles)
+- GitHub integration
+- Git Workflow configuration
+- Environment configuration file setup
 
-詳細は `project-bootstrap-prompt.md` を参照してください。
+See `project-bootstrap-prompt.md` for details.
 
 ---
 
-### ℹ️  ヘルプ
+### Help
 
 #### `/ypm-help`
-このヘルプメッセージを表示します。
+Displays this help message.
 
 ---
 
-## YPMの原則
+## YPM Principles
 
-### 読み取り専用
-YPMは他のプロジェクトを**読み取り専用**で監視します。変更できるのはYPM自身のファイルのみです。
+### Read-Only
+YPM monitors other projects in **read-only** mode. Only YPM's own files can be modified.
 
-### 役割分担
-- **YPM**: プロジェクト監視・進捗管理・新規プロジェクト立ち上げ支援
-- **各プロジェクト**: 実装・開発・テスト（各プロジェクトの専用Claude Codeセッションで実施）
-
----
-
-## 参考ドキュメント
-
-- **CLAUDE.md** - YPMのプロジェクト指示書
-- **project-bootstrap-prompt.md** - 新規プロジェクト立ち上げガイド
-- **config.example.yml** - 設定ファイルのサンプル
+### Role Division
+- **YPM**: Project monitoring, progress management, new project launch support
+- **Each Project**: Implementation, development, testing (conducted in dedicated Claude Code sessions for each project)
 
 ---
 
-## よくある使い方
+## Reference Documentation
 
-### 1. セッション開始時
+- **CLAUDE.md** - YPM project instructions
+- **project-bootstrap-prompt.md** - New project launch guide
+- **config.example.yml** - Sample configuration file
+
+---
+
+## Common Usage
+
+### 1. At Session Start
 ```
 /ypm
 ```
-ウェルカムメッセージを表示して、何ができるか確認します。
+Display the welcome message to see available options.
 
-### 2. プロジェクト状況を確認したい
+### 2. Check Project Status
 ```
 /ypm-update
 ```
-全プロジェクトをスキャンして最新の状況を把握します。
+Scan all projects to get the latest status.
 
-### 3. 次に何をすべきか知りたい
+### 3. Know What to Do Next
 ```
 /ypm-next
 ```
-優先度の高いタスクを確認します。
+Check high-priority tasks.
 
-### 4. 新しいプロジェクトを始めたい
+### 4. Start a New Project
 ```
 /ypm-new
 ```
-対話形式でプロジェクトをセットアップします。
+Set up a project interactively.
 
 ---
 
-**YPMで複数プロジェクトを効率的に管理しましょう！** 🚀
+**Manage multiple projects efficiently with YPM!**

--- a/.claude/commands/ypm-new.md
+++ b/.claude/commands/ypm-new.md
@@ -1,24 +1,27 @@
-新規プロジェクトの立ち上げを支援します。
+<!-- Language Handling: Check ~/.ypm/config.yml for settings.language -->
+<!-- If language is not "en", translate all output to that language -->
 
-`project-bootstrap-prompt.md` に基づき、以下の8フェーズで対話形式でセットアップします：
+Assists with launching new projects.
 
-## セットアップフェーズ
+Based on `project-bootstrap-prompt.md`, set up interactively through the following 8 phases:
 
-1. **プロジェクト企画**: ヒアリングを通じて要件を固める（目的、機能、技術スタック）
-2. **ディレクトリ作成**: ローカルディレクトリ作成とGit初期化
-3. **ドキュメント整備**: DDD・TDD・DRY原則に基づく開発環境構築
-4. **GitHub連携**: リモートリポジトリ作成と初期プッシュ
-5. **Git Workflow設定**: ブランチ戦略とルール確立
-6. **環境設定ファイル整備**: `.gitignore`、`.claude/settings.json`
-7. **ドキュメント管理ルール確立**: 実装とドキュメントの同期維持
-8. **最終確認**: 開発開始の準備完了
+## Setup Phases
 
-## セットアップ完了後
+1. **Project Planning**: Finalize requirements through interviews (purpose, features, tech stack)
+2. **Directory Creation**: Create local directory and initialize Git
+3. **Documentation Setup**: Build development environment based on DDD/TDD/DRY principles
+4. **GitHub Integration**: Create remote repository and initial push
+5. **Git Workflow Setup**: Establish branch strategy and rules
+6. **Environment Configuration**: Set up `.gitignore`, `.claude/settings.json`
+7. **Documentation Management Rules**: Maintain sync between implementation and documentation
+8. **Final Check**: Ready to start development
 
-- **ユーザーは新しいプロジェクトディレクトリに移動してください**
-- **そのプロジェクト専用のClaude Codeセッションで開発を開始してください**
-- YPMは次回の `/ypm-update` で自動的に監視対象に追加します
+## After Setup Completion
 
-## 実行方法
+- **User should move to the new project directory**
+- **Start development in a dedicated Claude Code session for that project**
+- YPM will automatically add it to monitored projects on the next `/ypm-update`
 
-`project-bootstrap-prompt.md` の内容を参照しながら、各フェーズを対話形式で進めてください。
+## Execution Method
+
+Proceed through each phase interactively while referring to `project-bootstrap-prompt.md`.

--- a/.claude/commands/ypm-next.md
+++ b/.claude/commands/ypm-next.md
@@ -1,22 +1,25 @@
-`PROJECT_STATUS.md` から各プロジェクトの「次のタスク」を抽出し、優先度順に表示してください。
+<!-- Language Handling: Check ~/.ypm/config.yml for settings.language -->
+<!-- If language is not "en", translate all output to that language -->
 
-**表示形式**:
-- プロジェクト名
-- 現在のPhase
-- 次のタスク
-- 最終更新日
+Extract "next tasks" from `PROJECT_STATUS.md` for each project and display them in priority order.
 
-**優先順位**:
-1. アクティブなプロジェクト（最近1週間以内に更新）
-2. 実装進捗が高いプロジェクト
-3. Phase順
+**Display Format**:
+- Project name
+- Current Phase
+- Next task
+- Last update date
 
-**推奨アクション**:
-- 最も優先度の高いプロジェクトを提案
-- 次に取り組むべきタスクを明確化
+**Priority Order**:
+1. Active projects (updated within the last week)
+2. Projects with higher implementation progress
+3. Phase order
 
-**⚠️ CRITICAL: 報告時の注意**:
-- PROJECT_STATUS.mdに記載された「次のタスク」をそのまま表示する
-- 新たな計画や機能を創作しない
-- GitHubのIssueがある場合は、Issue番号を併記する
-- 情報源が不明な場合は「（情報源不明）」と付記する
+**Recommended Actions**:
+- Suggest the highest priority project
+- Clarify the next task to work on
+
+**CRITICAL: Reporting Notes**:
+- Display the "next tasks" as recorded in PROJECT_STATUS.md
+- Do not create new plans or features
+- If there are GitHub Issues, include the Issue numbers
+- If the source is unclear, append "(source unknown)"

--- a/.claude/commands/ypm-open.md
+++ b/.claude/commands/ypm-open.md
@@ -1,570 +1,556 @@
+<!-- Language Handling: Check ~/.ypm/config.yml for settings.language -->
+<!-- If language is not "en", translate all output to that language -->
+
 # YPM - Open Project in Editor
 
-YPMで管理しているプロジェクトを指定したエディタで開きます。
+Opens projects managed by YPM in a specified editor.
 
-## サブコマンド
+## Subcommands
 
-- **(引数なし)**: ignore除外の一覧から選択（デフォルトエディタで開く）
-- `<プロジェクト名> [エディタ名]`: プロジェクトを指定エディタで開く
-- `all`: ignore含む全プロジェクトから選択
-- `ignore-list`: ignore設定済みプロジェクト一覧表示
-- `add-ignore`: プロジェクトをignoreに追加
-- `remove-ignore`: ignoreから削除
-- `--editor [エディタ名]`: デフォルトエディタの設定・表示
+- **(no arguments)**: Select from list (excluding ignored) and open in default editor
+- `<project_name> [editor_name]`: Open project in specified editor
+- `all`: Select from all projects including ignored
+- `ignore-list`: Show projects in ignore list
+- `add-ignore`: Add project to ignore list
+- `remove-ignore`: Remove project from ignore list
+- `--editor [editor_name]`: Show/set default editor
 
-## 使用例
+## Usage Examples
 
 ```
-/ypm-open                    # 通常モード（デフォルトエディタ）
-/ypm-open oshireq           # oshireqをデフォルトエディタで開く
-/ypm-open oshireq cursor    # oshireqをCursorで開く
-/ypm-open OnsetSpace terminal  # OnsetSpaceをTerminal.appで開く
-/ypm-open all               # 全表示モード
-/ypm-open --editor          # 現在のデフォルトエディタを表示
-/ypm-open --editor cursor   # デフォルトをCursorに設定
-/ypm-open ignore-list       # ignore一覧
-/ypm-open add-ignore        # ignoreに追加
-/ypm-open remove-ignore     # ignoreから削除
+/ypm-open                    # Normal mode (default editor)
+/ypm-open myproject          # Open myproject in default editor
+/ypm-open myproject cursor   # Open myproject in Cursor
+/ypm-open myproject terminal # Open myproject in Terminal.app
+/ypm-open all                # Full display mode
+/ypm-open --editor           # Show current default editor
+/ypm-open --editor cursor    # Set default to Cursor
+/ypm-open ignore-list        # Show ignore list
+/ypm-open add-ignore         # Add to ignore
+/ypm-open remove-ignore      # Remove from ignore
 ```
 
-**対応エディタ**: `code` (VS Code), `cursor` (Cursor), `zed` (Zed), `terminal` (Terminal.app)
+**Supported Editors**: `code` (VS Code), `cursor` (Cursor), `zed` (Zed), `terminal` (Terminal.app)
 
 ---
 
-## 実行手順
+## Execution Steps
 
-### 共通STEP: 引数の確認
+### Common STEP: Check Arguments
 
-引数を確認し、対応するモードに分岐：
-- 引数なし → **モード1: 通常モード**
-- `<プロジェクト名> [エディタ名]` → **モード1: 通常モード**（直接プロジェクト指定）
-- `all` → **モード2: 全表示モード**
-- `ignore-list` → **モード3: ignore一覧**
-- `add-ignore` → **モード4: ignore追加**
-- `remove-ignore` → **モード5: ignore削除**
-- `--editor [エディタ名]` → **モード6: エディタ設定**
+Check arguments and branch to corresponding mode:
+- No arguments → **Mode 1: Normal Mode**
+- `<project_name> [editor_name]` → **Mode 1: Normal Mode** (direct project specification)
+- `all` → **Mode 2: Full Display Mode**
+- `ignore-list` → **Mode 3: Ignore List**
+- `add-ignore` → **Mode 4: Add Ignore**
+- `remove-ignore` → **Mode 5: Remove Ignore**
+- `--editor [editor_name]` → **Mode 6: Editor Settings**
 
 ---
 
-## モード1: 通常モード（引数なし または プロジェクト名指定）
+## Mode 1: Normal Mode (no arguments or project name specified)
 
-### STEP 1: config.ymlとエディタCLIの確認
+### STEP 1: Check config.yml and Editor CLI
 
-#### 1-1. config.ymlからデフォルトエディタを取得
-
-```bash
-# config.ymlを読み込み
-# editor.default の値を取得（例: code, cursor, zed）
-```
-
-#### 1-2. 第2引数がある場合、エディタを上書き
-
-- 第2引数 (`cursor`, `code`, `zed` 等) が指定されている場合、そのエディタを使用
-- 第2引数がない場合、config.ymlのデフォルトを使用
-
-#### 1-3. エディタCLIの確認
-
-**Terminal.app以外のエディタの場合**:
+#### 1-1. Get default editor from config.yml
 
 ```bash
-which <エディタ名>
+# Read config.yml
+# Get editor.default value (e.g., code, cursor, zed)
 ```
 
-**結果が空の場合**:
+#### 1-2. Override editor if second argument exists
+
+- If second argument (`cursor`, `code`, `zed`, etc.) is specified, use that editor
+- If no second argument, use default from config.yml
+
+#### 1-3. Check Editor CLI
+
+**For editors other than Terminal.app**:
+
+```bash
+which <editor_name>
 ```
-❌ <エディタ名> CLI が見つかりません。
 
-<エディタ名>のCLIをインストールしてください。
+**If result is empty**:
+```
+Editor <editor_name> CLI not found.
 
-【VS Code (code)】
-1. VS Codeを開く
+Please install the <editor_name> CLI.
+
+[VS Code (code)]
+1. Open VS Code
 2. Command Palette (Cmd+Shift+P)
-3. "Shell Command: Install 'code' command in PATH" を実行
+3. Run "Shell Command: Install 'code' command in PATH"
 
-【Cursor (cursor)】
-1. Cursorを開く
+[Cursor (cursor)]
+1. Open Cursor
 2. Command Palette (Cmd+Shift+P)
-3. "Shell Command: Install 'cursor' command in PATH" を実行
+3. Run "Shell Command: Install 'cursor' command in PATH"
 
-【Zed (zed)】
-1. Zedを開く
+[Zed (zed)]
+1. Open Zed
 2. Command Palette (Cmd+Shift+P)
-3. "zed: Install CLI" を実行
+3. Run "zed: Install CLI"
 
-インストール後、再度このコマンドを実行してください。
+Please run this command again after installation.
 ```
-→ **処理を中断**
+→ **Abort processing**
 
-**Terminal.appの場合**:
-- CLI確認は不要（macOS組み込みのため）
-- そのまま次のSTEPへ進む
+**For Terminal.app**:
+- CLI check not needed (built into macOS)
+- Proceed to next STEP
 
-### STEP 2: PROJECT_STATUS.mdとconfig.ymlの読み込み
+### STEP 2: Read PROJECT_STATUS.md and config.yml
 
 ```bash
-# ReadツールでPROJECT_STATUS.mdを読み込み
-# Readツールでconfig.ymlを読み込み
+# Use Read tool to read PROJECT_STATUS.md
+# Use Read tool to read config.yml
 ```
 
-**PROJECT_STATUS.mdが存在しない場合**:
+**If PROJECT_STATUS.md does not exist**:
 ```
-❌ PROJECT_STATUS.md が見つかりません。
+PROJECT_STATUS.md not found.
 
-先に /ypm-update を実行してプロジェクトをスキャンしてください。
+Please run /ypm-update first to scan projects.
 ```
-→ **処理を中断**
+→ **Abort processing**
 
-### STEP 3: プロジェクト一覧の抽出と除外
+### STEP 3: Extract Project List and Exclusions
 
-#### 3-1. PROJECT_STATUS.mdから抽出
+#### 3-1. Extract from PROJECT_STATUS.md
 
-1. **アクティブプロジェクト**（`## 🔥 アクティブプロジェクト` セクション）
-2. **開発中プロジェクト**（`## 🚧 開発中` セクション）
-3. **休止中プロジェクト**（`## 💤 休止中` セクション）
+1. **Active Projects** (`## Active Projects` section)
+2. **Developing Projects** (`## Developing` section)
+3. **Dormant Projects** (`## Dormant` section)
 
-**抽出ルール**:
-- `### プロジェクト名` の行からプロジェクト名を取得
-- `- **概要**: ...` から簡単な説明を取得
-- `- **実装進捗**: XX%` から進捗を取得
-- `- **ドキュメント**: [...]` からプロジェクトパスを抽出
-  - 例: `[CLAUDE.md](/Users/yamato/Src/proj_max_mcp/MaxMCP/CLAUDE.md)`
-  - → プロジェクトパス: `/Users/yamato/Src/proj_max_mcp/MaxMCP`
+**Extraction Rules**:
+- Get project name from `### ProjectName` line
+- Get brief description from `- **Overview**: ...`
+- Get progress from `- **Implementation Progress**: XX%`
+- Extract project path from `- **Documentation**: [...]`
+  - Example: `[CLAUDE.md](/path/to/project/CLAUDE.md)`
+  - → Project path: `/path/to/project`
 
-#### 3-2. Git worktreeの除外
+#### 3-2. Exclude Git Worktrees
 
-以下の条件に**いずれか**該当するプロジェクトは除外：
-- プロジェクト名が `-main` で終わる
-- プロジェクト名が `-develop` で終わる
-- 概要に「worktree」が含まれる
+Exclude projects that match **any** of the following:
+- Project name ends with `-main`
+- Project name ends with `-develop`
+- Overview contains "worktree"
 
-#### 3-3. ignore_in_openの除外（通常モードのみ）
+#### 3-3. Exclude ignore_in_open (Normal Mode Only)
 
-config.ymlの`monitor.ignore_in_open`リストに含まれるプロジェクトを除外。
+Exclude projects in the `monitor.ignore_in_open` list in config.yml.
 
-### STEP 4: 番号付き一覧表示
+### STEP 4: Display Numbered List
 
 ```
-## 利用可能なプロジェクト（12個）
+## Available Projects (12)
 
-### 🔥 アクティブ（1週間以内に更新）
-1. Slack_MCP - Slack-Claude Bridge MCP（v1.0.0リリース準備中、95%）
-2. CVI - Claude Voice Integration（v2.0.0リリース済み、100%）
-3. MaxMCP - Max/MSP用ネイティブMCPサーバー（実装中、35%）
-4. MaxMSP-MCP-Server-multipatch - Max/MSP MCPサーバー研究版（80%）
-5. picopr - メールマガジン自動化システム（15%）
-6. redmine-mcp-server - Redmine REST API MCPサーバー（100%）
-7. InstrVo - 楽器演奏を歌声に変換（MVP開発、70%）
-8. Claude-code - Claude Code活用ガイド
-9. git-dotfiles-manager - プライベート設定ファイル管理（90%）
-10. TabClear - P2Pタブ管理・共有システム（設計段階、5%）
-11. oshireq - 推し活リクエスト（本番稼働中）
+### Active (Updated within 1 week)
+1. ProjectA - Description (95%)
+2. ProjectB - Description (100%)
+3. ProjectC - Description (35%)
+...
 
-### 🚧 開発中（1ヶ月以内に更新）
-12. DUNGIA - ダンジョンタイムアタックゲーム（設計中、0%）
-13. my_first_turnip - 自動取引PDCAシステム（実験段階、30%）
-14. orbitscore - ライブコーディングDSL（オーディオ実装、20%）
+### Developing (Updated within 1 month)
+12. ProjectX - Description (0%)
+...
 
-※ 非表示: 2個（全て表示: /ypm-open all）
+* Hidden: 2 (show all: /ypm-open all)
 
-番号またはプロジェクト名を入力してください:
+Enter number or project name:
 ```
 
-### STEP 5: ユーザー入力処理
+### STEP 5: User Input Processing
 
-**入力パターン**:
+**Input Patterns**:
 
-#### 5-1. 番号入力（例: `3`）
-- 該当番号のプロジェクトを選択 → STEP 6へ
+#### 5-1. Number Input (e.g., `3`)
+- Select project with that number → Go to STEP 6
 
-#### 5-2. プロジェクト名入力（例: `max`）
-- 大文字小文字を区別せず部分一致検索
-- **1件マッチ**: そのプロジェクトを選択 → STEP 6へ
-- **複数マッチ**:
+#### 5-2. Project Name Input (e.g., `proj`)
+- Case-insensitive partial match search
+- **1 match**: Select that project → Go to STEP 6
+- **Multiple matches**:
   ```
-  複数のプロジェクトがマッチしました：
+  Multiple projects matched:
 
-  1. MaxMCP
-  2. MaxMSP-MCP-Server-multipatch
+  1. ProjectA
+  2. ProjectB
 
-  番号を入力してください:
+  Enter number:
   ```
-  → 再度番号入力を待つ → STEP 6へ
+  → Wait for number input again → Go to STEP 6
 
-- **0件マッチ**:
+- **0 matches**:
   ```
-  ❌ プロジェクト "xxx" が見つかりませんでした。
+  Project "xxx" not found.
 
-  正確なプロジェクト名または番号を指定してください。
+  Please specify exact project name or number.
   ```
-  → **処理を中断**
+  → **Abort processing**
 
-### STEP 6: エディタでプロジェクトを開く
+### STEP 6: Open Project in Editor
 
-#### 6-1. Terminal.app以外のエディタの場合
+#### 6-1. For Editors Other Than Terminal.app
 
-**重要**: 環境変数をクリアしてエディタを起動します。これにより、各プロジェクトの`.node-version`等が正しく読み込まれます。
+**Important**: Launch editor with environment variables cleared. This ensures each project's `.node-version` etc. are read correctly.
 
 ```bash
-env -u NODENV_VERSION -u NODENV_DIR -u RBENV_VERSION -u PYENV_VERSION <エディタ名> /path/to/project
+env -u NODENV_VERSION -u NODENV_DIR -u RBENV_VERSION -u PYENV_VERSION <editor_name> /path/to/project
 ```
 
-**クリアする環境変数**:
-- `NODENV_VERSION` - Node.jsバージョン（nodenv）
-- `NODENV_DIR` - nodenvディレクトリ
-- `RBENV_VERSION` - Rubyバージョン（rbenv）
-- `PYENV_VERSION` - Pythonバージョン（pyenv）
+**Environment Variables to Clear**:
+- `NODENV_VERSION` - Node.js version (nodenv)
+- `NODENV_DIR` - nodenv directory
+- `RBENV_VERSION` - Ruby version (rbenv)
+- `PYENV_VERSION` - Python version (pyenv)
 
-#### 6-2. Terminal.appの場合
+#### 6-2. For Terminal.app
 
-**重要**: ディレクトリ移動後にシェルを再初期化することで、環境変数が正しく設定されます。
+**Important**: Reinitialize shell after changing directory to set environment variables correctly.
 
 ```bash
 osascript -e 'tell application "Terminal" to do script "cd '"$PROJECT_PATH"' && exec $SHELL"'
 ```
 
-**仕組み**:
-1. Terminal.appを起動
-2. 指定されたプロジェクトディレクトリに移動
-3. `exec $SHELL`でシェルを再初期化
-4. 新しいディレクトリのコンテキストで`.zshrc`/`.bashrc`が実行される
-5. nodenv/rbenv等の環境マネージャーがプロジェクト固有のバージョンを検出
+#### 6-3. Success Message
 
-#### 6-3. 成功時のメッセージ
-
-**Terminal.app以外**:
+**For editors other than Terminal.app**:
 ```
-✅ <エディタ表示名>で "MaxMCP" を開きました。
+Opened "ProjectName" in <EditorDisplayName>.
 
-プロジェクトパス: /Users/yamato/Src/proj_max_mcp/MaxMCP
-エディタ: <エディタ表示名> (<エディタ名>)
+Project path: /path/to/project
+Editor: <EditorDisplayName> (<editor_name>)
 
-※ 環境変数（NODENV_VERSION等）をクリアした状態で起動しました。
-各プロジェクトの設定ファイル（.node-version等）が正しく読み込まれます。
+* Launched with environment variables (NODENV_VERSION, etc.) cleared.
+Project config files (.node-version, etc.) will be read correctly.
 ```
 
-**Terminal.app**:
+**For Terminal.app**:
 ```
-✅ Terminal.appで "MaxMCP" を開きました。
+Opened "ProjectName" in Terminal.app.
 
-プロジェクトパス: /Users/yamato/Src/proj_max_mcp/MaxMCP
-エディタ: Terminal.app (terminal)
+Project path: /path/to/project
+Editor: Terminal.app (terminal)
 
-※ プロジェクトディレクトリに移動後、シェルを再初期化しました。
-各プロジェクトの設定ファイル（.node-version等）が正しく読み込まれます。
+* Shell reinitialized after moving to project directory.
+Project config files (.node-version, etc.) will be read correctly.
 ```
 
-**エディタ表示名の対応**:
+**Editor Display Name Mapping**:
 - `code` → "VS Code"
 - `cursor` → "Cursor"
 - `zed` → "Zed"
 - `terminal` → "Terminal.app"
 
-**失敗時のメッセージ**:
+**Failure Message**:
 ```
-❌ <エディタ表示名>の起動に失敗しました。
+Failed to launch <EditorDisplayName>.
 
-エラー: <エラーメッセージ>
+Error: <error_message>
 
-手動で以下のコマンドを実行してください：
-env -u NODENV_VERSION -u NODENV_DIR -u RBENV_VERSION -u PYENV_VERSION <エディタ名> /Users/yamato/Src/proj_max_mcp/MaxMCP
+Please run the following command manually:
+env -u NODENV_VERSION -u NODENV_DIR -u RBENV_VERSION -u PYENV_VERSION <editor_name> /path/to/project
 ```
 
 ---
 
-## モード2: 全表示モード（`/ypm-open all`）
+## Mode 2: Full Display Mode (`/ypm-open all`)
 
-### 処理
+### Processing
 
-**STEP 1-2**: モード1と同じ
+**STEP 1-2**: Same as Mode 1
 
-**STEP 3**: プロジェクト抽出
-- worktreeは除外
-- **ignore_in_openは除外しない**（これが通常モードとの違い）
+**STEP 3**: Project Extraction
+- Exclude worktrees
+- **Do not exclude ignore_in_open** (this is the difference from Normal Mode)
 
-**STEP 4**: 番号付き一覧表示（ignore含む）
+**STEP 4**: Display numbered list (including ignored)
 
 ```
-## 利用可能なプロジェクト（全16個）
+## Available Projects (All 16)
 
-### 🔥 アクティブ
-1-11. （通常モードと同じ）
+### Active
+1-11. (same as Normal Mode)
 
-### 🚧 開発中
-12-14. （通常モードと同じ）
+### Developing
+12-14. (same as Normal Mode)
 
-### 💤 休止中・その他（ignore設定済み）
-15. godot-mcp - Godot Engine向けMCPサーバー（休止中）
-16. loto7loto6Generator - ロト番号生成ツール（レガシー、完成済み）
+### Dormant/Other (in ignore list)
+15. ProjectY - Description (dormant)
+16. ProjectZ - Description (legacy, complete)
 
-番号またはプロジェクト名を入力してください:
+Enter number or project name:
 ```
 
-**STEP 5-6**: モード1と同じ
+**STEP 5-6**: Same as Mode 1
 
 ---
 
-## モード3: ignore一覧（`/ypm-open ignore-list`）
+## Mode 3: Ignore List (`/ypm-open ignore-list`)
 
-### 処理
+### Processing
 
 ```bash
-# config.ymlを読み込み
-# monitor.ignore_in_openセクションを抽出
+# Read config.yml
+# Extract monitor.ignore_in_open section
 ```
 
-**表示**:
+**Display**:
 ```
-## Ignore設定済みプロジェクト
+## Projects in Ignore List
 
-1. godot-mcp
-2. loto7loto6Generator
+1. project-a
+2. project-b
 
-削除: /ypm-open remove-ignore
-追加: /ypm-open add-ignore
+Remove: /ypm-open remove-ignore
+Add: /ypm-open add-ignore
 ```
 
-**ignore_in_openが空の場合**:
+**If ignore_in_open is empty**:
 ```
-✅ 現在ignoreに設定されているプロジェクトはありません。
+No projects currently in ignore list.
 
-追加: /ypm-open add-ignore
+Add: /ypm-open add-ignore
 ```
 
 ---
 
-## モード4: ignore追加（`/ypm-open add-ignore`）
+## Mode 4: Add Ignore (`/ypm-open add-ignore`)
 
-### STEP 1-3: モード1と同じ（通常モード）
+### STEP 1-3: Same as Mode 1 (Normal Mode)
 
-### STEP 4: プロジェクト一覧表示
+### STEP 4: Display Project List
 
 ```
-## ignoreに追加するプロジェクトを選択
+## Select project to add to ignore
 
-現在表示中のプロジェクト（12個）:
-1. Slack_MCP
-2. CVI
-3. MaxMCP
+Currently displayed projects (12):
+1. ProjectA
+2. ProjectB
 ...
-14. orbitscore
 
-番号またはプロジェクト名を入力してください:
+Enter number or project name:
 ```
 
-### STEP 5: プロジェクト選択（モード1と同じ）
+### STEP 5: Project Selection (same as Mode 1)
 
-### STEP 6: config.ymlに追加
+### STEP 6: Add to config.yml
 
-選択されたプロジェクト名を`monitor.ignore_in_open`リストに追加。
+Add selected project name to `monitor.ignore_in_open` list.
 
 ```yaml
 monitor:
   ignore_in_open:
-    - godot-mcp
-    - loto7loto6Generator
-    - orbitscore  # 追加
+    - project-a
+    - project-b
+    - project-c  # added
 ```
 
-**成功メッセージ**:
+**Success Message**:
 ```
-✅ "orbitscore" をignoreに追加しました。
+Added "project-c" to ignore list.
 
-config.ymlを更新:
+Updated config.yml:
   monitor.ignore_in_open:
-    - godot-mcp
-    - loto7loto6Generator
-    - orbitscore
+    - project-a
+    - project-b
+    - project-c
 
-次回から /ypm-open では表示されません。
-全て表示: /ypm-open all
+This project will not appear in /ypm-open from next time.
+Show all: /ypm-open all
 ```
 
 ---
 
-## モード5: ignore削除（`/ypm-open remove-ignore`）
+## Mode 5: Remove Ignore (`/ypm-open remove-ignore`)
 
-### STEP 1: config.yml読み込み
+### STEP 1: Read config.yml
 
 ```bash
-# config.ymlを読み込み
-# monitor.ignore_in_openセクションを抽出
+# Read config.yml
+# Extract monitor.ignore_in_open section
 ```
 
-**ignore_in_openが空の場合**:
+**If ignore_in_open is empty**:
 ```
-✅ 現在ignoreに設定されているプロジェクトはありません。
+No projects currently in ignore list.
 
-追加: /ypm-open add-ignore
+Add: /ypm-open add-ignore
 ```
-→ **処理を中断**
+→ **Abort processing**
 
-### STEP 2: ignore一覧表示
+### STEP 2: Display Ignore List
 
 ```
-## ignoreから削除するプロジェクトを選択
+## Select project to remove from ignore
 
-1. godot-mcp
-2. loto7loto6Generator
-3. orbitscore
+1. project-a
+2. project-b
+3. project-c
 
-番号またはプロジェクト名を入力してください:
+Enter number or project name:
 ```
 
-### STEP 3: プロジェクト選択
+### STEP 3: Project Selection
 
-番号または名前で選択（モード1のSTEP 5と同じロジック）
+Select by number or name (same logic as Mode 1 STEP 5)
 
-### STEP 4: config.ymlから削除
+### STEP 4: Remove from config.yml
 
-選択されたプロジェクト名を`monitor.ignore_in_open`リストから削除。
+Remove selected project name from `monitor.ignore_in_open` list.
 
 ```yaml
 monitor:
   ignore_in_open:
-    - godot-mcp
-    - loto7loto6Generator
-    # orbitscoreを削除
+    - project-a
+    - project-b
+    # project-c removed
 ```
 
-**成功メッセージ**:
+**Success Message**:
 ```
-✅ "orbitscore" をignoreから削除しました。
+Removed "project-c" from ignore list.
 
-config.ymlを更新:
+Updated config.yml:
   monitor.ignore_in_open:
-    - godot-mcp
-    - loto7loto6Generator
+    - project-a
+    - project-b
 
-次回から /ypm-open で表示されます。
+This project will appear in /ypm-open from next time.
 ```
 
 ---
 
-## モード6: エディタ設定（`/ypm-open --editor [エディタ名]`）
+## Mode 6: Editor Settings (`/ypm-open --editor [editor_name]`)
 
-### STEP 1: 引数の確認
+### STEP 1: Check Arguments
 
-#### 引数がない場合（`/ypm-open --editor`）
+#### No argument (`/ypm-open --editor`)
 
-現在のデフォルトエディタを表示します。
+Display current default editor.
 
 ```bash
-# config.ymlを読み込み
-# editor.default の値を取得
+# Read config.yml
+# Get editor.default value
 ```
 
-**表示メッセージ**:
+**Display Message**:
 ```
-📝 現在のデフォルトエディタ
+Current Default Editor
 
-エディタ: VS Code (code)
+Editor: VS Code (code)
 
-変更方法: /ypm-open --editor <エディタ名>
-対応エディタ: code (VS Code), cursor (Cursor), zed (Zed), terminal (Terminal.app)
+Change: /ypm-open --editor <editor_name>
+Supported: code (VS Code), cursor (Cursor), zed (Zed), terminal (Terminal.app)
 ```
 
-#### 引数がある場合（`/ypm-open --editor cursor`）
+#### With argument (`/ypm-open --editor cursor`)
 
-デフォルトエディタを変更します。
+Change default editor.
 
-### STEP 2: エディタ名のバリデーション
+### STEP 2: Validate Editor Name
 
-指定されたエディタ名が対応しているか確認します。
+Check if specified editor name is supported.
 
-**対応エディタ**:
+**Supported Editors**:
 - `code` - VS Code
 - `cursor` - Cursor
 - `zed` - Zed
 - `terminal` - Terminal.app
 
-**対応していない場合**:
+**If not supported**:
 ```
-❌ 未対応のエディタです: "xxx"
+Unsupported editor: "xxx"
 
-対応エディタ:
+Supported editors:
 - code (VS Code)
 - cursor (Cursor)
 - zed (Zed)
 - terminal (Terminal.app)
 
-使用例: /ypm-open --editor cursor
+Example: /ypm-open --editor cursor
 ```
-→ **処理を中断**
+→ **Abort processing**
 
-### STEP 3: config.ymlの更新
+### STEP 3: Update config.yml
 
-`editor.default`の値を指定されたエディタ名に変更します。
+Change `editor.default` value to specified editor name.
 
 ```yaml
-# 変更前
+# Before
 editor:
   default: code
 
-# 変更後
+# After
 editor:
   default: cursor
 ```
 
-### STEP 4: 成功メッセージ
+### STEP 4: Success Message
 
 ```
-✅ デフォルトエディタを変更しました
+Default editor changed
 
-変更前: VS Code (code)
-変更後: Cursor (cursor)
+Before: VS Code (code)
+After: Cursor (cursor)
 
-config.ymlを更新:
+Updated config.yml:
   editor.default: cursor
 
-次回から /ypm-open で Cursor が使用されます。
+Cursor will be used for /ypm-open from next time.
 ```
 
 ---
 
-## 重要な注意事項
+## Important Notes
 
-### 1. Git worktreeの除外
+### 1. Git Worktree Exclusion
 
-Git worktree（例: `MaxMCP-main`, `redmine-mcp-server-main`, `InstrVo-develop`）は**全モードで自動的に除外**されます。これらは開発用ではなく確認用のため、選択肢に含めません。
+Git worktrees (e.g., `ProjectA-main`, `ProjectB-develop`) are **automatically excluded in all modes**. These are for review purposes, not development, so they are not included in selections.
 
-### 2. ignoreとexcludeの違い
+### 2. Difference Between ignore and exclude
 
-- **exclude**: スキャン対象から完全に除外（PROJECT_STATUS.mdにも表示されない）
-- **ignore_in_open**: スキャン対象だが、ypm-openでデフォルト非表示（allで表示可能）
+- **exclude**: Completely excluded from scanning (not shown in PROJECT_STATUS.md)
+- **ignore_in_open**: Scanned but hidden by default in ypm-open (visible with `all`)
 
-### 3. config.ymlの保存
+### 3. Saving config.yml
 
-ignore追加・削除時、エディタ設定変更時は、config.ymlファイルを**必ず保存**してください。Writeツールを使用します。
+When adding/removing from ignore or changing editor settings, **always save** the config.yml file. Use the Write tool.
 
-### 4. PROJECT_STATUS.mdの更新
+### 4. Updating PROJECT_STATUS.md
 
-プロジェクト一覧が古い場合、先に `/ypm-update` を実行してください。
+If the project list is outdated, run `/ypm-update` first.
 
-### 5. エディタCLIのインストール
+### 5. Editor CLI Installation
 
-各エディタのCLIがインストールされていない場合、プロジェクトを開くことができません。STEP 1でインストール方法を案内します。
-
----
-
-## エラーハンドリング
-
-| エラー | 対処法 |
-|--------|--------|
-| エディタCLIがない | インストール手順を表示して中断 |
-| 未対応のエディタ | 対応エディタ一覧を表示して中断 |
-| PROJECT_STATUS.mdがない | `/ypm-update` の実行を促して中断 |
-| config.ymlがない | エラーメッセージを表示して中断 |
-| プロジェクトが見つからない | エラーメッセージを表示して中断 |
-| 複数マッチ | 候補を番号付きで再表示 |
-| エディタ起動失敗 | エラーメッセージと手動コマンドを表示 |
+If each editor's CLI is not installed, you cannot open projects. Installation instructions are shown in STEP 1.
 
 ---
 
-## 仕様書
+## Error Handling
 
-詳細な仕様は以下を参照：
+| Error | Action |
+|-------|--------|
+| Editor CLI not found | Show installation instructions and abort |
+| Unsupported editor | Show supported editor list and abort |
+| PROJECT_STATUS.md not found | Prompt to run `/ypm-update` and abort |
+| config.yml not found | Show error message and abort |
+| Project not found | Show error message and abort |
+| Multiple matches | Re-display candidates with numbers |
+| Editor launch failure | Show error message and manual command |
+
+---
+
+## Specification Document
+
+See the following for detailed specifications:
 - **[docs/development/ypm-open-spec.md](../../docs/development/ypm-open-spec.md)**
 
 ---
 
-**このコマンドを実行した後、必ず成功/失敗メッセージをユーザーに表示してください。**
+**Always display success/failure message to user after executing this command.**

--- a/.claude/commands/ypm-trufflehog-scan.md
+++ b/.claude/commands/ypm-trufflehog-scan.md
@@ -1,163 +1,165 @@
+<!-- Language Handling: Check ~/.ypm/config.yml for settings.language -->
+<!-- If language is not "en", translate all output to that language -->
+
 # YPM - TruffleHog Security Scan
 
-YPMで管理している全プロジェクトに対してTruffleHogセキュリティスキャンを実行します。
+Runs TruffleHog security scan on all projects managed by YPM.
 
-## 概要
+## Overview
 
-このコマンドは以下を実行します：
-1. `python scripts/scan_projects.py`を実行してプロジェクト一覧を取得
-2. 各プロジェクトに対してTruffleHogスキャンを実行
-3. 検出された問題を見やすく表示
+This command performs the following:
+1. Run `python scripts/scan_projects.py` to get project list
+2. Execute TruffleHog scan on each project
+3. Display detected issues in a readable format
 
-## 実行手順
+## Execution Steps
 
-### STEP 1: TruffleHogのインストール確認
+### STEP 1: Check TruffleHog Installation
 
 ```bash
 which trufflehog
 ```
 
-**trufflehogがインストールされていない場合**:
+**If trufflehog is not installed**:
 ```
-❌ TruffleHogがインストールされていません。
+TruffleHog is not installed.
 
-インストール方法:
+Installation:
 brew install trufflehog
 
-インストール後、再度このコマンドを実行してください。
+Please run this command again after installation.
 ```
-→ **処理を中断**
+→ **Abort processing**
 
-### STEP 2: プロジェクトスキャン実行
+### STEP 2: Execute Project Scan
 
 ```bash
 python scripts/scan_projects.py
 ```
 
-スキャン結果のJSONを読み取り、各プロジェクトの`security_scan`情報を確認します。
+Read the scan result JSON and check `security_scan` information for each project.
 
-### STEP 3: スキャン結果の表示
+### STEP 3: Display Scan Results
 
-#### 3-1. サマリー表示
+#### 3-1. Summary Display
 
 ```
-## 🔒 TruffleHog Security Scan Results
+## TruffleHog Security Scan Results
 
-**スキャン実行日時**: 2025-11-11 10:30
+**Scan Date/Time**: 2025-11-11 10:30
 
-**サマリー**:
-- 総プロジェクト数: 27個
-- スキャン実施: 27個
-- 問題検出: 1個
-- クリーン: 26個
+**Summary**:
+- Total Projects: 27
+- Scanned: 27
+- Issues Found: 1
+- Clean: 26
 ```
 
-#### 3-2. 問題が検出されたプロジェクト
+#### 3-2. Projects with Issues
 
-問題が検出されたプロジェクトを優先表示：
+Display projects with detected issues first:
 
 ```
 ---
 
-## ⚠️ セキュリティ問題が検出されたプロジェクト
+## Security Issues Detected
 
-### godot-mcp
-- **パス**: /Users/yamato/Src/MCPServer/godot-mcp
-- **ブランチ**: main
-- **検出された問題数**: 6個
-- **最終更新**: 8ヶ月前
-- **推奨アクション**:
-  1. プロジェクトディレクトリで詳細確認: `cd /Users/yamato/Src/MCPServer/godot-mcp`
-  2. TruffleHog詳細スキャン: `trufflehog git file://. --json | jq`
-  3. 検出された機密情報を削除またはgit-filter-repoで履歴クリーン
-
----
-```
-
-#### 3-3. クリーンなプロジェクト（オプション）
-
-```
-## ✅ クリーンなプロジェクト（26個）
-
-問題は検出されませんでした：
-- Claude-code
-- CVI
-- InstrVo
-- MaxMCP
-- ... (他22個)
-```
-
-### STEP 4: 次のアクション提案
-
-```
-## 📝 推奨される次のアクション
-
-### 問題が検出された場合
-1. 各プロジェクトで詳細スキャンを実行
-2. 検出された機密情報を確認
-3. 必要に応じて履歴クリーンまたはシークレットローテーション
-
-### 定期的なスキャン
-- 週次または月次でこのコマンドを実行することを推奨
-- 新しいプロジェクトを追加した際にも実行
-
-### 個別プロジェクトのスキャン
-各プロジェクト内で `/trufflehog-scan` を使用して個別にスキャン可能
-```
+### project-name
+- **Path**: /path/to/project
+- **Branch**: main
+- **Issues Found**: 6
+- **Last Update**: 8 months ago
+- **Recommended Actions**:
+  1. Check details in project directory: `cd /path/to/project`
+  2. Detailed TruffleHog scan: `trufflehog git file://. --json | jq`
+  3. Remove detected secrets or clean history with git-filter-repo
 
 ---
+```
 
-## 出力例
-
-### 問題なしの場合
+#### 3-3. Clean Projects (Optional)
 
 ```
-## 🔒 TruffleHog Security Scan Results
+## Clean Projects (26)
 
-**スキャン実行日時**: 2025-11-11 10:30
+No issues detected:
+- Project1
+- Project2
+- Project3
+- ... (22 more)
+```
 
-**サマリー**:
-- 総プロジェクト数: 27個
-- スキャン実施: 27個
-- 問題検出: 0個
-- クリーン: 27個
+### STEP 4: Suggest Next Actions
+
+```
+## Recommended Next Actions
+
+### If Issues Were Detected
+1. Run detailed scan for each project
+2. Review detected secrets
+3. Rotate secrets or clean history as needed
+
+### Regular Scanning
+- Recommend running this command weekly or monthly
+- Also run when adding new projects
+
+### Individual Project Scanning
+Use `/trufflehog-scan` within each project for individual scanning
+```
 
 ---
 
-## ✅ すべてのプロジェクトはクリーンです
+## Output Examples
 
-セキュリティ問題は検出されませんでした。
+### No Issues Found
+
+```
+## TruffleHog Security Scan Results
+
+**Scan Date/Time**: 2025-11-11 10:30
+
+**Summary**:
+- Total Projects: 27
+- Scanned: 27
+- Issues Found: 0
+- Clean: 27
+
+---
+
+## All Projects Are Clean
+
+No security issues were detected.
 ```
 
-### 問題ありの場合
+### Issues Found
 
-上記STEP 3の形式で表示
-
----
-
-## 重要な注意事項
-
-### 1. スキャン時間
-
-- 大量のプロジェクトがある場合、スキャンに時間がかかる可能性があります
-- プロジェクトあたり最大30秒のタイムアウト
-
-### 2. 誤検知の可能性
-
-TruffleHogは機密情報のパターンマッチングを行うため、誤検知の可能性があります。
-検出された内容を必ず確認してください。
-
-### 3. 履歴スキャン
-
-TruffleHogはGitの履歴全体をスキャンします。
-現在のコードに機密情報がなくても、過去のコミットに含まれていれば検出されます。
-
-### 4. プライバシー
-
-スキャン結果にはプロジェクト名やパスが含まれます。
-YPMの「プロジェクト情報の外部露出禁止」ポリシーに従い、
-この結果をGitコミットやPRに含めないでください。
+Display in STEP 3 format above
 
 ---
 
-**このコマンドを実行した後、必ず結果をユーザーに表示してください。**
+## Important Notes
+
+### 1. Scan Time
+
+- May take time if there are many projects
+- Maximum 30 second timeout per project
+
+### 2. False Positives
+
+TruffleHog performs pattern matching for secrets, so false positives are possible.
+Always verify detected content.
+
+### 3. History Scanning
+
+TruffleHog scans the entire Git history.
+Even if current code has no secrets, they will be detected if included in past commits.
+
+### 4. Privacy
+
+Scan results include project names and paths.
+Following YPM's "no external exposure of project information" policy,
+do not include these results in Git commits or PRs.
+
+---
+
+**Always display results to user after executing this command.**

--- a/.claude/commands/ypm-update.md
+++ b/.claude/commands/ypm-update.md
@@ -1,30 +1,33 @@
-全プロジェクトをスキャンして `PROJECT_STATUS.md` を更新してください。
+<!-- Language Handling: Check ~/.ypm/config.yml for settings.language -->
+<!-- If language is not "en", translate all output to that language -->
 
-**実行内容**:
-1. `python scripts/scan_projects.py` を実行してプロジェクト情報を収集
-   - Git worktree判定（.gitファイル/ディレクトリで判定）
-   - プロジェクト分類（アクティブ/開発中/休止中）
-2. スキャン結果（JSON形式）を読み取り
-3. アクティブなプロジェクトの詳細情報を `CLAUDE.md` から収集
-4. `PROJECT_STATUS.md` を人間が読みやすい形式で更新
-   - worktreeの場合、プロジェクト名に「（Git worktree）」を追加
-5. 完了
+Scan all projects and update `PROJECT_STATUS.md`.
 
-**重要**: このコマンドは**Git操作を行いません**。`PROJECT_STATUS.md`はローカルファイルとして更新されます（`.gitignore`済み）。
+**Execution Steps**:
+1. Run `python scripts/scan_projects.py` to collect project information
+   - Git worktree detection (determined by .git file/directory)
+   - Project classification (active/developing/dormant)
+2. Read scan results (JSON format)
+3. Collect detailed information from `CLAUDE.md` for active projects
+4. Update `PROJECT_STATUS.md` in human-readable format
+   - For worktrees, add "(Git worktree)" to project name
+5. Complete
 
-**注意事項**:
-- 他のプロジェクトのファイルは読み取り専用です（変更禁止）
-- YPM自身のファイルのみ変更可能です
-- スキャンスクリプトが自動的に新規プロジェクトを検出します
-- PROJECT_STATUS.mdはGit管理外（日常的な運用タスクのため）
+**Important**: This command **does not perform Git operations**. `PROJECT_STATUS.md` is updated as a local file (already in `.gitignore`).
 
-**🚨 CRITICAL: 正確性の確保**:
-- **「次のタスク」は以下の情報源からのみ取得すること**:
-  - GitHubのIssue（`gh issue list`コマンド）
-  - 最新のコミットメッセージ
-  - プロジェクトのCLAUDE.md、README.mdに明記された内容
-- **絶対にやってはいけないこと**:
-  - 存在しない機能や計画を創作する
-  - 実装されていない機能を「実装中」と記載する
-  - ドキュメントに記載のない「次のタスク」を推測で書く
-- **不明な場合**: 「不明」「記載なし」「GitHubに該当Issueなし」と正直に記載
+**Notes**:
+- Other project files are read-only (modification prohibited)
+- Only YPM's own files can be modified
+- The scan script automatically detects new projects
+- PROJECT_STATUS.md is not under Git management (for routine operational tasks)
+
+**CRITICAL: Ensuring Accuracy**:
+- **"Next tasks" must be obtained ONLY from the following sources**:
+  - GitHub Issues (`gh issue list` command)
+  - Latest commit messages
+  - Content explicitly stated in project's CLAUDE.md, README.md
+- **Absolutely prohibited**:
+  - Making up non-existent features or plans
+  - Listing unimplemented features as "in progress"
+  - Writing "next tasks" by guessing when not documented
+- **When uncertain**: Honestly state "Unknown", "Not documented", or "No matching GitHub Issue"

--- a/.claude/commands/ypm.md
+++ b/.claude/commands/ypm.md
@@ -1,20 +1,23 @@
-**YPM (Your Project Manager)** へようこそ。
+<!-- Language Handling: Check ~/.ypm/config.yml for settings.language -->
+<!-- If language is not "en", translate all output to that language -->
 
-このシステムは `/Users/yamato/Src/` 配下の複数プロジェクトを監視し、進捗を一元管理します。
+**Welcome to YPM (Your Project Manager)**
 
-**できること**:
-- 全プロジェクトの状況を一覧化（Git情報 + ドキュメントから自動収集）
-- 次のタスクと優先順位を整理
+This system monitors multiple projects under your configured directories and provides centralized progress management.
 
-**よく使うコマンド**:
-1. 📊 **"プロジェクト状況を更新して"** → 全プロジェクトをスキャンして `PROJECT_STATUS.md` を更新
-2. 📋 **"次にやるべきタスクは？"** → アクティブなプロジェクトの次のアクションを表示
-3. 🔥 **"アクティブなプロジェクトは？"** → 最近更新されたプロジェクトを確認
+**Features**:
+- List all project statuses (automatically collected from Git info + documentation)
+- Organize next tasks and priorities
 
-**カスタムコマンド**:
-- `/ypm` - このヘルプメッセージを表示
-- `/ypm-update` - プロジェクト状況を更新
-- `/ypm-next` - 次のタスクを表示
-- `/ypm-active` - アクティブなプロジェクトを表示
+**Common Commands**:
+1. **"Update project status"** - Scan all projects and update `PROJECT_STATUS.md`
+2. **"What should I do next?"** - Show next actions for active projects
+3. **"Show active projects"** - Check recently updated projects
 
-どうされますか？
+**Custom Commands**:
+- `/ypm` - Show this help message
+- `/ypm-update` - Update project status
+- `/ypm-next` - Show next tasks
+- `/ypm-active` - Show active projects
+
+What would you like to do?

--- a/commands/active.md
+++ b/commands/active.md
@@ -2,6 +2,9 @@
 description: "Show only active projects updated within 1 week"
 ---
 
+<!-- Language Handling: Check ~/.ypm/config.yml for settings.language -->
+<!-- If language is not "en", translate all output to that language -->
+
 Display only active projects updated within 1 week from `~/.ypm/PROJECT_STATUS.md`.
 
 **Prerequisites**:

--- a/commands/export-community.md
+++ b/commands/export-community.md
@@ -2,6 +2,9 @@
 description: "Export private repository to public community version"
 ---
 
+<!-- Language Handling: Check ~/.ypm/config.yml for settings.language -->
+<!-- If language is not "en", translate all output to that language -->
+
 # /ypm-export-community - Export Private Repository to Public Community Version
 
 This command exports from a private repository to public community version.
@@ -16,12 +19,14 @@ Execute the following steps **strictly**:
 
 ### STEP 0: Language Detection
 
-Detect language from user's recent messages for subsequent AskUserQuestion.
+Check `~/.ypm/config.yml` for `settings.language` setting.
 
 **Detection rules**:
-- User's recent message contains Japanese keywords -> **Japanese**
-- Otherwise (English only) -> **English**
-- Default: **Japanese**
+- If `settings.language` is set, use that language
+- If not set or config doesn't exist, detect from user's recent messages:
+  - User's recent message contains Japanese keywords -> **Japanese**
+  - Otherwise (English only) -> **English**
+- Default: **English**
 
 Note detected language internally for use in STEP 3 and STEP 4-2 AskUserQuestion.
 

--- a/commands/help.md
+++ b/commands/help.md
@@ -2,6 +2,9 @@
 description: "Show detailed YPM help with all available commands"
 ---
 
+<!-- Language Handling: Check ~/.ypm/config.yml for settings.language -->
+<!-- If language is not "en", translate all output to that language -->
+
 # YPM (Your Project Manager) - Help
 
 ## Overview

--- a/commands/new.md
+++ b/commands/new.md
@@ -2,6 +2,9 @@
 description: "Launch interactive new project setup wizard"
 ---
 
+<!-- Language Handling: Check ~/.ypm/config.yml for settings.language -->
+<!-- If language is not "en", translate all output to that language -->
+
 Launch new project setup wizard.
 
 Based on `project-bootstrap-prompt.md`, set up through 8 phases interactively:

--- a/commands/next.md
+++ b/commands/next.md
@@ -2,6 +2,9 @@
 description: "Show next tasks for all projects in priority order"
 ---
 
+<!-- Language Handling: Check ~/.ypm/config.yml for settings.language -->
+<!-- If language is not "en", translate all output to that language -->
+
 Extract "next tasks" from `~/.ypm/PROJECT_STATUS.md` and display in priority order.
 
 **Prerequisites**:

--- a/commands/open.md
+++ b/commands/open.md
@@ -2,6 +2,9 @@
 description: "Open a project in your preferred editor"
 ---
 
+<!-- Language Handling: Check ~/.ypm/config.yml for settings.language -->
+<!-- If language is not "en", translate all output to that language -->
+
 # YPM - Open Project in Editor
 
 Open a YPM-managed project in specified editor.

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -2,6 +2,9 @@
 description: "Initialize YPM data directory and configuration"
 ---
 
+<!-- Language Handling: Check ~/.ypm/config.yml for settings.language -->
+<!-- If language is not "en", translate all output to that language -->
+
 # YPM Setup - Initial Configuration
 
 Set up YPM for global usage. This command creates the data directory and configuration file.

--- a/commands/start.md
+++ b/commands/start.md
@@ -2,6 +2,9 @@
 description: "Show YPM welcome message and quick commands"
 ---
 
+<!-- Language Handling: Check ~/.ypm/config.yml for settings.language -->
+<!-- If language is not "en", translate all output to that language -->
+
 **YPM (Your Project Manager)** - Multi-project progress tracking system.
 
 This system monitors multiple projects in configured directories and centralizes progress management.

--- a/commands/trufflehog-scan.md
+++ b/commands/trufflehog-scan.md
@@ -2,6 +2,9 @@
 description: "Run TruffleHog security scan on all managed projects"
 ---
 
+<!-- Language Handling: Check ~/.ypm/config.yml for settings.language -->
+<!-- If language is not "en", translate all output to that language -->
+
 # YPM - TruffleHog Security Scan
 
 Run TruffleHog security scan on all YPM-managed projects.

--- a/commands/update.md
+++ b/commands/update.md
@@ -2,6 +2,9 @@
 description: "Scan all projects and update PROJECT_STATUS.md"
 ---
 
+<!-- Language Handling: Check ~/.ypm/config.yml for settings.language -->
+<!-- If language is not "en", translate all output to that language -->
+
 Scan all projects and update `~/.ypm/PROJECT_STATUS.md`.
 
 **Prerequisites**:

--- a/config.example.yml
+++ b/config.example.yml
@@ -1,84 +1,90 @@
-# YPM設定ファイル（テンプレート）
+# YPM Configuration File (Template)
 #
-# このファイルをコピーして config.yml を作成してください:
+# Copy this file to create your config.yml:
 #   cp config.example.yml config.yml
 #
-# その後、あなたの環境に合わせて config.yml を編集してください。
+# Then edit config.yml to match your environment.
 
-# 監視対象ディレクトリ
+# Monitor target directories
 monitor:
-  # 監視するディレクトリ（複数指定可能）
-  # 例:
+  # Directories to monitor (multiple allowed)
+  # Examples:
   #   - /Users/yourname/Projects
   #   - /home/yourname/workspace
   #   - ~/Documents/dev
   directories:
-    - /path/to/your/projects    # TODO: あなたのプロジェクトディレクトリに変更してください
+    - /path/to/your/projects    # TODO: Change to your project directory
 
-  # 除外パターン（このプロジェクト自身など）
-  # 相対パスまたは部分一致で指定
+  # Exclusion patterns (e.g., this project itself)
+  # Specify as relative path or partial match
   exclude:
-    - proj_YPM/YPM         # YPM自身を除外
-    # 必要に応じて追加してください:
+    - proj_YPM/YPM         # Exclude YPM itself
+    # Add more as needed:
     # - "node_modules"
     # - ".git"
     # - "tmp"
 
-  # プロジェクト検出パターン
-  # Gitリポジトリを検出するためのディレクトリパターン
-  # ディレクトリ構造に応じて調整可能
+  # Project detection patterns
+  # Directory patterns for detecting Git repositories
+  # Adjust according to your directory structure
   #
-  # 例:
-  #   - "*"              # 1階層（直下の全プロジェクト）
-  #   - "work/*"         # 2階層（work/project1, work/project2, ...）
-  #   - "proj_*/*"       # 特定の命名規則（proj_xxx/yyy）
+  # Examples:
+  #   - "*"              # 1 level (all projects directly under)
+  #   - "work/*"         # 2 levels (work/project1, work/project2, ...)
+  #   - "proj_*/*"       # Specific naming convention (proj_xxx/yyy)
   patterns:
-    - "*"                # デフォルト: 直下の全プロジェクト
-    # 必要に応じて追加してください:
+    - "*"                # Default: all projects directly under
+    # Add more as needed:
     # - "personal/*"
     # - "client/*"
-    # - "work/*/*"       # 3階層
+    # - "work/*/*"       # 3 levels
 
-# プロジェクト分類の基準
+# Project classification criteria
 classification:
-  # アクティブ: 最近N日以内に更新
-  # デフォルト: 7日（1週間）
-  # 調整例: 3日（短期）、14日（2週間）
+  # Active: updated within N days
+  # Default: 7 days (1 week)
+  # Adjust examples: 3 days (short), 14 days (2 weeks)
   active_days: 7
 
-  # 休止中: N日以上更新なし
-  # デフォルト: 30日（1ヶ月）
-  # 調整例: 60日（2ヶ月）、90日（3ヶ月）
+  # Dormant: no updates for N days or more
+  # Default: 30 days (1 month)
+  # Adjust examples: 60 days (2 months), 90 days (3 months)
   inactive_days: 30
 
-# 進捗率の推測基準
-# YPMはドキュメントやGit履歴から進捗率を推測します
-# 以下の基準を参考に、PROJECT_STATUS.mdで手動調整も可能です
+# Progress estimation criteria
+# YPM estimates progress from documentation and Git history
+# Use these as reference; manual adjustment in PROJECT_STATUS.md is also possible
 progress:
-  phase_0: 0-20    # 設計・計画段階（ドキュメント作成、アーキテクチャ設計）
-  phase_1: 20-30   # 開発環境構築（依存関係インストール、初期設定）
-  phase_2: 30-60   # 基本機能実装（コア機能の開発）
-  phase_3: 60-80   # テスト・改善（バグ修正、リファクタリング）
-  phase_4: 80-100  # 本番稼働・機能拡張（運用開始、新機能追加）
+  phase_0: 0-20    # Design/planning stage (documentation, architecture design)
+  phase_1: 20-30   # Development environment setup (dependencies, initial config)
+  phase_2: 30-60   # Core feature implementation
+  phase_3: 60-80   # Testing/improvement (bug fixes, refactoring)
+  phase_4: 80-100  # Production/feature expansion (deployment, new features)
 
-# エディタ設定
+# Editor settings
 editor:
-  # /ypm-open コマンドで使用するデフォルトエディタ
-  # 対応エディタ: code (VS Code), cursor (Cursor), zed (Zed)
-  # 変更方法: /ypm-open --editor <エディタ名>
+  # Default editor for /open command
+  # Supported: code (VS Code), cursor (Cursor), zed (Zed)
+  # Change with: /open --editor <editor_name>
   default: code
 
-# その他の設定
+# Other settings
 settings:
-  # Gitリポジトリでないディレクトリも含める
-  # false: Gitリポジトリのみ監視（推奨）
-  # true: 全ディレクトリを監視（注意: Git非管理プロジェクトも表示されます）
+  # Language setting for YPM output
+  # Supported: en (English), ja (Japanese)
+  # Default: en
+  # When set to non-English, Claude will translate output dynamically
+  language: en
+
+  # Include non-Git directories
+  # false: Monitor only Git repositories (recommended)
+  # true: Monitor all directories (Note: non-Git projects will also appear)
   include_non_git: false
 
-  # ドキュメント読み込みの優先順序
-  # YPMは各プロジェクトの概要を以下の順序で取得します
-  # 必要に応じて順序を変更できます
+  # Documentation loading priority
+  # YPM retrieves project overview in this order
+  # Adjust order as needed
   doc_priority:
-    - CLAUDE.md      # Claude Code向け指示書
-    - README.md      # プロジェクト概要
-    - docs/INDEX.md  # ドキュメント索引
+    - CLAUDE.md      # Claude Code instructions
+    - README.md      # Project overview
+    - docs/INDEX.md  # Documentation index

--- a/docs/guide-en.md
+++ b/docs/guide-en.md
@@ -426,6 +426,20 @@ YPM estimates project progress based on the following criteria:
 
 Edit `~/.ypm/config.yml` to customize YPM behavior.
 
+### Language Settings
+
+YPM supports multiple languages. Set your preferred language in `~/.ypm/config.yml`:
+
+```yaml
+settings:
+  language: en   # Options: en (English), ja (Japanese)
+```
+
+- **English (`en`)**: Default language, output displayed as-is
+- **Japanese (`ja`)**: Claude will dynamically translate all output to Japanese
+
+The language setting is applied during `/ypm:setup` when you select your preferred language, or you can change it manually in the config file.
+
 ### Adding Monitoring Targets
 
 Add to `directories` in `~/.ypm/config.yml`:
@@ -592,9 +606,10 @@ Powered by Claude Code
 ## Related Documentation
 
 - **[README.md](../README.md)** - Project overview (English)
-- **[詳細ガイド（日本語）](guide-ja.md)** - Japanese detailed guide
 - **[CLAUDE.md](../CLAUDE.md)** - Claude Code instructions
 - **[docs/INDEX.md](INDEX.md)** - Documentation index
+
+> **Note**: Japanese documentation (`guide-ja.md`) is deprecated. Use `settings.language: ja` in config for Japanese output.
 
 ---
 

--- a/docs/guide-ja.md
+++ b/docs/guide-ja.md
@@ -1,5 +1,13 @@
 # YPM 詳細ガイド（日本語）
 
+> **Note**: This document is deprecated. Please refer to [guide-en.md](./guide-en.md) as the primary documentation.
+> YPM now supports language settings in `~/.ypm/config.yml`. Set `settings.language: ja` for Japanese output - Claude will translate dynamically.
+
+> **注意**: このドキュメントは非推奨です。最新のドキュメントは [guide-en.md](./guide-en.md) を参照してください。
+> YPMは `~/.ypm/config.yml` で言語設定をサポートしています。`settings.language: ja` を設定すると、Claude が日本語に翻訳して出力します。
+
+---
+
 > YPM (Your Project Manager) の完全な使い方ガイド
 
 ---

--- a/scripts/onboarding.py
+++ b/scripts/onboarding.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 """
-YPM オンボーディングスクリプト
+YPM Onboarding Script
 
-新規ユーザーがYPMを初めて使用する際に、対話的に必要な情報を収集し、
-config.ymlを自動生成するウィザードスクリプト。
+An interactive wizard script that collects necessary information from new users
+when they first use YPM and automatically generates config.yml.
 
-仕様書: docs/development/onboarding-script-spec.md
+Specification: docs/development/onboarding-script-spec.md
 """
 
 import os
@@ -15,107 +15,217 @@ import subprocess
 import yaml
 from datetime import datetime
 
+# Supported languages
+SUPPORTED_LANGUAGES = {
+    'en': 'English',
+    'ja': '日本語 (Japanese)'
+}
+
 def main():
-    """メインエントリーポイント"""
+    """Main entry point"""
     print_welcome()
-    
-    # 既存config.ymlのチェック
+
+    # Language selection (first step)
+    language = ask_language()
+
+    # Check for existing config.yml
     if config_exists():
-        if not confirm_overwrite():
-            print("\n❌ セットアップを中止しました。")
-            print("既存のconfig.ymlを使用します。")
+        if not confirm_overwrite(language):
+            msg = {
+                'en': "\n❌ Setup cancelled.\nUsing existing config.yml.",
+                'ja': "\n❌ セットアップを中止しました。\n既存のconfig.ymlを使用します。"
+            }
+            print(msg[language])
             sys.exit(0)
-    
-    # 情報収集
-    directory = ask_directory()
-    pattern = ask_pattern(directory)
-    active_days = ask_active_days()
-    inactive_days = ask_inactive_days(active_days)
-    
-    # config.yml生成
-    generate_config(directory, pattern, active_days, inactive_days)
-    
-    # PROJECT_STATUS.md生成（オプション）
-    if ask_generate_status():
-        generate_project_status(directory, pattern)
-    
-    # 完了レポート
-    print_completion_report(directory, pattern, active_days, inactive_days)
+
+    # Collect information
+    directory = ask_directory(language)
+    pattern = ask_pattern(directory, language)
+    active_days = ask_active_days(language)
+    inactive_days = ask_inactive_days(active_days, language)
+
+    # Generate config.yml
+    generate_config(directory, pattern, active_days, inactive_days, language)
+
+    # Generate PROJECT_STATUS.md (optional)
+    if ask_generate_status(language):
+        generate_project_status(directory, pattern, language)
+
+    # Completion report
+    print_completion_report(directory, pattern, active_days, inactive_days, language)
 
 def print_welcome():
-    """ウェルカムメッセージ"""
+    """Welcome message (always in English first, then show language selection)"""
     print("\n" + "=" * 70)
-    print("🚀 YPM (Your Project Manager) - 初期設定ウィザード")
+    print("🚀 YPM (Your Project Manager) - Initial Setup Wizard")
     print("=" * 70)
-    print("\nこのウィザードで、YPMがプロジェクトを監視するための設定を行います。")
-    print("いくつかの質問に答えていただくだけで、config.ymlが自動生成されます。\n")
+    print("\nThis wizard will configure YPM to monitor your projects.")
+    print("Just answer a few questions and config.yml will be auto-generated.\n")
+
+def ask_language():
+    """Ask for language preference"""
+    print("-" * 70)
+    print("🌐 Language Selection / 言語選択")
+    print("-" * 70)
+    print("\nSelect your preferred language for YPM output:")
+    print("YPMの出力言語を選択してください:\n")
+
+    for i, (code, name) in enumerate(SUPPORTED_LANGUAGES.items(), 1):
+        print(f"  {i}. {name} ({code})")
+
+    while True:
+        choice = input("\nSelect [1]: ").strip()
+
+        if not choice:
+            choice = "1"
+
+        try:
+            idx = int(choice) - 1
+            if 0 <= idx < len(SUPPORTED_LANGUAGES):
+                lang_code = list(SUPPORTED_LANGUAGES.keys())[idx]
+                lang_name = SUPPORTED_LANGUAGES[lang_code]
+                print(f"\n✅ Selected: {lang_name}")
+                return lang_code
+        except ValueError:
+            pass
+
+        print("❌ Error: Please select a valid number.")
 
 def config_exists():
-    """config.ymlが存在するか確認"""
+    """Check if config.yml exists"""
     config_path = Path("config.yml")
     return config_path.exists()
 
-def confirm_overwrite():
-    """上書き確認"""
-    print("\n⚠️  警告: config.ymlが既に存在します。")
-    response = input("\n上書きしますか？ [y/N]: ").strip().lower()
+def confirm_overwrite(language):
+    """Confirm overwrite"""
+    msg = {
+        'en': "\n⚠️  Warning: config.yml already exists.\n\nOverwrite? [y/N]: ",
+        'ja': "\n⚠️  警告: config.ymlが既に存在します。\n\n上書きしますか？ [y/N]: "
+    }
+    response = input(msg[language]).strip().lower()
     return response in ['y', 'yes']
 
-def ask_directory():
-    """監視対象ディレクトリを尋ねる"""
+def ask_directory(language):
+    """Ask for monitored directory"""
+    msgs = {
+        'en': {
+            'header': "📁 STEP 1: Configure Monitored Directory",
+            'prompt': "Enter the path to the project directory YPM should monitor.",
+            'example': "Example: /Users/yourname/Projects, ~/workspace",
+            'input': "Directory to monitor: ",
+            'error_empty': "❌ Error: Please enter a path.",
+            'error_not_exist': "❌ Error: Directory does not exist: ",
+            'error_not_dir': "❌ Error: Path is not a directory: ",
+            'error_no_read': "❌ Error: No read permission: ",
+            'retry': "\nPlease try again.",
+            'success': "\n✅ Directory confirmed: "
+        },
+        'ja': {
+            'header': "📁 STEP 1: 監視対象ディレクトリの設定",
+            'prompt': "YPMが監視するプロジェクトディレクトリのパスを入力してください。",
+            'example': "例: /Users/yourname/Projects, ~/workspace",
+            'input': "監視対象ディレクトリ: ",
+            'error_empty': "❌ エラー: パスを入力してください。",
+            'error_not_exist': "❌ エラー: ディレクトリが存在しません: ",
+            'error_not_dir': "❌ エラー: パスがディレクトリではありません: ",
+            'error_no_read': "❌ エラー: 読み取り権限がありません: ",
+            'retry': "\nもう一度入力してください。",
+            'success': "\n✅ ディレクトリを確認しました: "
+        }
+    }
+    m = msgs[language]
+
     print("\n" + "-" * 70)
-    print("📁 STEP 1: 監視対象ディレクトリの設定")
+    print(m['header'])
     print("-" * 70)
-    print("\nYPMが監視するプロジェクトディレクトリのパスを入力してください。")
-    print("例: /Users/yourname/Projects, ~/workspace\n")
-    
+    print(f"\n{m['prompt']}")
+    print(f"{m['example']}\n")
+
     while True:
-        path_input = input("監視対象ディレクトリ: ").strip()
-        
+        path_input = input(m['input']).strip()
+
         if not path_input:
-            print("❌ エラー: パスを入力してください。")
+            print(m['error_empty'])
             continue
-        
-        # ~ を展開
+
+        # Expand ~
         path_expanded = Path(path_input).expanduser()
-        
-        # 存在確認
+
+        # Check existence
         if not path_expanded.exists():
-            print(f"❌ エラー: ディレクトリが存在しません: {path_expanded}")
-            print("\nもう一度入力してください。")
+            print(f"{m['error_not_exist']}{path_expanded}")
+            print(m['retry'])
             continue
-        
-        # ディレクトリ確認
+
+        # Check if directory
         if not path_expanded.is_dir():
-            print(f"❌ エラー: パスがディレクトリではありません: {path_expanded}")
-            print("\nもう一度入力してください。")
+            print(f"{m['error_not_dir']}{path_expanded}")
+            print(m['retry'])
             continue
-        
-        # 読み取り権限確認
+
+        # Check read permission
         if not os.access(path_expanded, os.R_OK):
-            print(f"❌ エラー: 読み取り権限がありません: {path_expanded}")
-            print("\n別のディレクトリを指定してください。")
+            print(f"{m['error_no_read']}{path_expanded}")
+            print(m['retry'])
             continue
-        
-        print(f"\n✅ ディレクトリを確認しました: {path_expanded}")
+
+        print(f"{m['success']}{path_expanded}")
         return str(path_expanded)
 
-def ask_pattern(directory):
-    """プロジェクト検出パターンを尋ねる"""
+def ask_pattern(directory, language):
+    """Ask for project detection pattern"""
+    msgs = {
+        'en': {
+            'header': "🔍 STEP 2: Configure Project Detection Pattern",
+            'analyzing': "Analyzing directory structure...",
+            'structure': "Directory structure: ",
+            'scan_fail': "Failed to scan directory: ",
+            'recommend': "\nRecommended project detection patterns:",
+            'opt1': "  1. * (all projects directly under)",
+            'opt2': "  2. work/* (under specific directory)",
+            'opt3': "  3. proj_*/* (specific naming convention, 2 levels)",
+            'opt4': "  4. Enter custom pattern",
+            'select': "\nSelect [1]: ",
+            'enter_dir': "Enter directory name (e.g., work): ",
+            'enter_prefix': "Enter prefix (e.g., proj_): ",
+            'enter_custom': "Enter custom pattern: ",
+            'error_empty': "❌ Error: Please enter a value.",
+            'error_select': "❌ Error: Please select 1-4."
+        },
+        'ja': {
+            'header': "🔍 STEP 2: プロジェクト検出パターンの設定",
+            'analyzing': "ディレクトリ構造を分析しています...",
+            'structure': "ディレクトリ構造: ",
+            'scan_fail': "ディレクトリのスキャンに失敗しました: ",
+            'recommend': "\n推奨プロジェクト検出パターン:",
+            'opt1': "  1. * (直下の全プロジェクト)",
+            'opt2': "  2. work/* (特定のディレクトリ配下)",
+            'opt3': "  3. proj_*/* (特定の命名規則、2階層)",
+            'opt4': "  4. カスタムパターンを入力",
+            'select': "\n選択してください [1]: ",
+            'enter_dir': "ディレクトリ名を入力してください (例: work): ",
+            'enter_prefix': "プレフィックスを入力してください (例: proj_): ",
+            'enter_custom': "カスタムパターンを入力してください: ",
+            'error_empty': "❌ エラー: 値を入力してください。",
+            'error_select': "❌ エラー: 1-4の番号を選択してください。"
+        }
+    }
+    m = msgs[language]
+
     print("\n" + "-" * 70)
-    print("🔍 STEP 2: プロジェクト検出パターンの設定")
+    print(m['header'])
     print("-" * 70)
-    print("\nディレクトリ構造を分析しています...\n")
-    
-    # ディレクトリ構造を表示
+    print(f"\n{m['analyzing']}\n")
+
+    # Display directory structure
     try:
         subdirs = [d.name for d in Path(directory).iterdir() if d.is_dir() and not d.name.startswith('.')]
-        subdirs = sorted(subdirs[:10])  # 最初の10個まで
-        
-        print(f"ディレクトリ構造: {directory}/")
+        subdirs = sorted(subdirs[:10])  # First 10
+
+        print(f"{m['structure']}{directory}/")
         for subdir in subdirs:
             print(f"  ├── {subdir}/")
-            # 2階層目も確認
+            # Check 2nd level too
             subdir_path = Path(directory) / subdir
             try:
                 sub_subdirs = [d.name for d in subdir_path.iterdir() if d.is_dir() and not d.name.startswith('.')]
@@ -123,214 +233,323 @@ def ask_pattern(directory):
                     print(f"  │   ├── {sub}/")
             except:
                 pass
-        
+
         if len(subdirs) > 10:
-            print(f"  ... (他 {len(list(Path(directory).iterdir())) - 10}個)")
+            print(f"  ... (+{len(list(Path(directory).iterdir())) - 10} more)")
     except Exception as e:
-        print(f"ディレクトリのスキャンに失敗しました: {e}")
-    
-    print("\n推奨プロジェクト検出パターン:")
-    print("  1. * (直下の全プロジェクト)")
-    print("  2. work/* (特定のディレクトリ配下)")
-    print("  3. proj_*/* (特定の命名規則、2階層)")
-    print("  4. カスタムパターンを入力")
-    
+        print(f"{m['scan_fail']}{e}")
+
+    print(m['recommend'])
+    print(m['opt1'])
+    print(m['opt2'])
+    print(m['opt3'])
+    print(m['opt4'])
+
     while True:
-        choice = input("\n選択してください [1]: ").strip()
-        
+        choice = input(m['select']).strip()
+
         if not choice:
             choice = "1"
-        
+
         if choice == "1":
             return "*"
         elif choice == "2":
-            subdir = input("ディレクトリ名を入力してください (例: work): ").strip()
+            subdir = input(m['enter_dir']).strip()
             if subdir:
                 return f"{subdir}/*"
             else:
-                print("❌ エラー: ディレクトリ名を入力してください。")
+                print(m['error_empty'])
         elif choice == "3":
-            prefix = input("プレフィックスを入力してください (例: proj_): ").strip()
+            prefix = input(m['enter_prefix']).strip()
             if prefix:
                 return f"{prefix}*/*"
             else:
-                print("❌ エラー: プレフィックスを入力してください。")
+                print(m['error_empty'])
         elif choice == "4":
-            pattern = input("カスタムパターンを入力してください: ").strip()
+            pattern = input(m['enter_custom']).strip()
             if pattern:
                 return pattern
             else:
-                print("❌ エラー: パターンを入力してください。")
+                print(m['error_empty'])
         else:
-            print("❌ エラー: 1-4の番号を選択してください。")
+            print(m['error_select'])
 
-def ask_active_days():
-    """アクティブ基準日数を尋ねる"""
+def ask_active_days(language):
+    """Ask for active days threshold"""
+    msgs = {
+        'en': {
+            'header': "📅 STEP 3: Configure Classification Criteria",
+            'prompt': "Set how many days since last update to consider a project \"active\".",
+            'input': "\nActive project threshold (days) [7]: ",
+            'error_positive': "❌ Error: Please enter a positive integer.",
+            'error_max': "❌ Error: Please enter a value of 365 or less.",
+            'error_invalid': "❌ Error: Invalid number: "
+        },
+        'ja': {
+            'header': "📅 STEP 3: 分類基準の設定",
+            'prompt': "何日以内に更新されたプロジェクトを「アクティブ」とするか設定します。",
+            'input': "\nアクティブプロジェクトの基準日数 [7]: ",
+            'error_positive': "❌ エラー: 正の整数を入力してください。",
+            'error_max': "❌ エラー: 365日以下の値を入力してください。",
+            'error_invalid': "❌ エラー: 無効な数値です: "
+        }
+    }
+    m = msgs[language]
+
     print("\n" + "-" * 70)
-    print("📅 STEP 3: 分類基準の設定")
+    print(m['header'])
     print("-" * 70)
-    print("\n何日以内に更新されたプロジェクトを「アクティブ」とするか設定します。")
-    
+    print(f"\n{m['prompt']}")
+
     while True:
-        response = input("\nアクティブプロジェクトの基準日数 [7]: ").strip()
-        
+        response = input(m['input']).strip()
+
         if not response:
             return 7
-        
+
         try:
             days = int(response)
             if days <= 0:
-                print("❌ エラー: 正の整数を入力してください。")
+                print(m['error_positive'])
                 continue
             if days > 365:
-                print("❌ エラー: 365日以下の値を入力してください。")
+                print(m['error_max'])
                 continue
             return days
         except ValueError:
-            print(f"❌ エラー: 無効な数値です: {response}")
-            print("正の整数を入力してください。")
+            print(f"{m['error_invalid']}{response}")
 
-def ask_inactive_days(active_days):
-    """休止中基準日数を尋ねる"""
-    print("\n何日以上更新されていないプロジェクトを「休止中」とするか設定します。")
-    
+def ask_inactive_days(active_days, language):
+    """Ask for inactive days threshold"""
+    msgs = {
+        'en': {
+            'prompt': "Set how many days without updates to consider a project \"dormant\".",
+            'input': "\nDormant project threshold (days) [30]: ",
+            'error_positive': "❌ Error: Please enter a positive integer.",
+            'error_max': "❌ Error: Please enter a value of 365 or less.",
+            'error_invalid': "❌ Error: Invalid number: ",
+            'error_greater': "❌ Error: Please enter a value greater than active threshold ({} days)."
+        },
+        'ja': {
+            'prompt': "何日以上更新されていないプロジェクトを「休止中」とするか設定します。",
+            'input': "\n休止中プロジェクトの基準日数 [30]: ",
+            'error_positive': "❌ エラー: 正の整数を入力してください。",
+            'error_max': "❌ エラー: 365日以下の値を入力してください。",
+            'error_invalid': "❌ エラー: 無効な数値です: ",
+            'error_greater': "❌ エラー: アクティブ基準日数（{}日）より大きい値を入力してください。"
+        }
+    }
+    m = msgs[language]
+
+    print(f"\n{m['prompt']}")
+
     while True:
-        response = input(f"\n休止中プロジェクトの基準日数 [30]: ").strip()
-        
+        response = input(m['input']).strip()
+
         if not response:
             days = 30
         else:
             try:
                 days = int(response)
             except ValueError:
-                print(f"❌ エラー: 無効な数値です: {response}")
-                print("正の整数を入力してください。")
+                print(f"{m['error_invalid']}{response}")
                 continue
-        
+
         if days <= 0:
-            print("❌ エラー: 正の整数を入力してください。")
+            print(m['error_positive'])
             continue
         if days > 365:
-            print("❌ エラー: 365日以下の値を入力してください。")
+            print(m['error_max'])
             continue
         if days <= active_days:
-            print(f"❌ エラー: アクティブ基準日数（{active_days}日）より大きい値を入力してください。")
+            print(m['error_greater'].format(active_days))
             continue
-        
+
         return days
 
-def generate_config(directory, pattern, active_days, inactive_days):
-    """config.ymlを生成"""
-    print("\n" + "-" * 70)
-    print("⚙️  config.ymlを生成しています...")
-    print("-" * 70)
-    
-    config_data = {
-        '# YPM設定ファイル': None,
-        '# 自動生成日時': datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
-        'monitor': {
-            'directories': [directory],
-            'exclude': ['proj_YPM/YPM'],
-            'patterns': [pattern]
+def generate_config(directory, pattern, active_days, inactive_days, language):
+    """Generate config.yml"""
+    msgs = {
+        'en': {
+            'header': "⚙️  Generating config.yml...",
+            'success': "✅ config.yml generated."
         },
-        'classification': {
-            'active_days': active_days,
-            'inactive_days': inactive_days
-        },
-        'progress': {
-            'phase_0': '0-20',
-            'phase_1': '20-30',
-            'phase_2': '30-60',
-            'phase_3': '60-80',
-            'phase_4': '80-100'
-        },
-        'settings': {
-            'include_non_git': False,
-            'doc_priority': ['CLAUDE.md', 'README.md', 'docs/INDEX.md']
+        'ja': {
+            'header': "⚙️  config.ymlを生成しています...",
+            'success': "✅ config.ymlを生成しました。"
         }
     }
-    
-    # コメント付きYAMLを生成
-    with open('config.yml', 'w', encoding='utf-8') as f:
-        f.write(f"# YPM設定ファイル\n")
-        f.write(f"# 自動生成日時: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n")
-        
-        yaml.dump({
-            'monitor': config_data['monitor'],
-            'classification': config_data['classification'],
-            'progress': config_data['progress'],
-            'settings': config_data['settings']
-        }, f, default_flow_style=False, allow_unicode=True, sort_keys=False)
-    
-    print("✅ config.ymlを生成しました。")
+    m = msgs[language]
 
-def ask_generate_status():
-    """PROJECT_STATUS.md生成を尋ねる"""
     print("\n" + "-" * 70)
-    print("📊 STEP 4: 初回PROJECT_STATUS.mdの生成（オプション）")
+    print(m['header'])
     print("-" * 70)
-    print("\n初回のPROJECT_STATUS.mdを今すぐ生成することもできます。")
-    print("（Claude Codeで後ほど生成することも可能です）")
-    
-    # Gitが利用可能か確認
+
+    # Generate YAML with comments
+    with open('config.yml', 'w', encoding='utf-8') as f:
+        f.write(f"# YPM Configuration File\n")
+        f.write(f"# Auto-generated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n")
+
+        yaml.dump({
+            'monitor': {
+                'directories': [directory],
+                'exclude': ['proj_YPM/YPM'],
+                'patterns': [pattern]
+            },
+            'classification': {
+                'active_days': active_days,
+                'inactive_days': inactive_days
+            },
+            'progress': {
+                'phase_0': '0-20',
+                'phase_1': '20-30',
+                'phase_2': '30-60',
+                'phase_3': '60-80',
+                'phase_4': '80-100'
+            },
+            'editor': {
+                'default': 'code'
+            },
+            'settings': {
+                'language': language,
+                'include_non_git': False,
+                'doc_priority': ['CLAUDE.md', 'README.md', 'docs/INDEX.md']
+            }
+        }, f, default_flow_style=False, allow_unicode=True, sort_keys=False)
+
+    print(m['success'])
+
+def ask_generate_status(language):
+    """Ask whether to generate PROJECT_STATUS.md"""
+    msgs = {
+        'en': {
+            'header': "📊 STEP 4: Generate Initial PROJECT_STATUS.md (Optional)",
+            'prompt': "You can generate the initial PROJECT_STATUS.md now.",
+            'note': "(You can also generate it later with Claude Code)",
+            'git_warning': "\n⚠️  Warning: Git command not found.\nSkipping automatic PROJECT_STATUS.md generation.\nPlease generate it later with Claude Code.",
+            'input': "\nGenerate initial PROJECT_STATUS.md? [Y/n]: "
+        },
+        'ja': {
+            'header': "📊 STEP 4: 初回PROJECT_STATUS.mdの生成（オプション）",
+            'prompt': "初回のPROJECT_STATUS.mdを今すぐ生成することもできます。",
+            'note': "（Claude Codeで後ほど生成することも可能です）",
+            'git_warning': "\n⚠️  警告: Gitコマンドが見つかりません。\nPROJECT_STATUS.mdの自動生成をスキップします。\nClaude Codeで後ほど生成してください。",
+            'input': "\n初回のPROJECT_STATUS.mdを生成しますか？ [Y/n]: "
+        }
+    }
+    m = msgs[language]
+
+    print("\n" + "-" * 70)
+    print(m['header'])
+    print("-" * 70)
+    print(f"\n{m['prompt']}")
+    print(m['note'])
+
+    # Check if Git is available
     try:
         subprocess.run(['git', '--version'], capture_output=True, check=True)
     except:
-        print("\n⚠️  警告: Gitコマンドが見つかりません。")
-        print("PROJECT_STATUS.mdの自動生成をスキップします。")
-        print("Claude Codeで後ほど生成してください。")
+        print(m['git_warning'])
         return False
-    
-    response = input("\n初回のPROJECT_STATUS.mdを生成しますか？ [Y/n]: ").strip().lower()
+
+    response = input(m['input']).strip().lower()
     return response != 'n'
 
-def generate_project_status(directory, pattern):
-    """PROJECT_STATUS.mdを生成"""
-    print("\n" + "-" * 70)
-    print("📊 PROJECT_STATUS.mdを生成しています...")
-    print("-" * 70)
-    print("\nこの処理には時間がかかる場合があります...\n")
-    
-    # 簡易版のPROJECT_STATUS.mdを生成
-    # （完全版はClaude Codeに任せる）
-    with open('PROJECT_STATUS.md', 'w', encoding='utf-8') as f:
-        f.write("# プロジェクト状況一覧\n\n")
-        f.write(f"**最終更新**: {datetime.now().strftime('%Y-%m-%d %H:%M')}\n\n")
-        f.write("---\n\n")
-        f.write("## 📊 サマリー\n\n")
-        f.write("初回生成完了。Claude Codeで「プロジェクト状況を更新して」と指示してください。\n\n")
-    
-    print("✅ PROJECT_STATUS.md（初期版）を生成しました。")
-    print("   詳細な情報はClaude Codeで更新してください。")
+def generate_project_status(directory, pattern, language):
+    """Generate PROJECT_STATUS.md"""
+    msgs = {
+        'en': {
+            'header': "📊 Generating PROJECT_STATUS.md...",
+            'wait': "This may take a moment...",
+            'success': "✅ PROJECT_STATUS.md (initial version) generated.",
+            'note': "   For detailed information, update with Claude Code."
+        },
+        'ja': {
+            'header': "📊 PROJECT_STATUS.mdを生成しています...",
+            'wait': "この処理には時間がかかる場合があります...",
+            'success': "✅ PROJECT_STATUS.md（初期版）を生成しました。",
+            'note': "   詳細な情報はClaude Codeで更新してください。"
+        }
+    }
+    m = msgs[language]
 
-def print_completion_report(directory, pattern, active_days, inactive_days):
-    """完了レポートを表示"""
+    print("\n" + "-" * 70)
+    print(m['header'])
+    print("-" * 70)
+    print(f"\n{m['wait']}\n")
+
+    # Generate simplified PROJECT_STATUS.md
+    # (Full version delegated to Claude Code)
+    with open('PROJECT_STATUS.md', 'w', encoding='utf-8') as f:
+        f.write("# Project Status Overview\n\n")
+        f.write(f"**Last Updated**: {datetime.now().strftime('%Y-%m-%d %H:%M')}\n\n")
+        f.write("---\n\n")
+        f.write("## Summary\n\n")
+        f.write("Initial generation complete. Please use Claude Code to run \"update project status\".\n\n")
+
+    print(m['success'])
+    print(m['note'])
+
+def print_completion_report(directory, pattern, active_days, inactive_days, language):
+    """Display completion report"""
+    msgs = {
+        'en': {
+            'header': "✅ Setup Complete!",
+            'dir': "📁 Monitored Directory:",
+            'pattern': "🔍 Detection Pattern:",
+            'active': "📊 Active Threshold:",
+            'days_within': "days",
+            'dormant': "💤 Dormant Threshold:",
+            'days_over': "days or more",
+            'files': "Generated files:",
+            'next_header': "🎉 Next Steps:",
+            'next_prompt': "In Claude Code, run:",
+            'next_command': '  "Update project status"',
+            'next_note': "This will collect all project information."
+        },
+        'ja': {
+            'header': "✅ セットアップが完了しました！",
+            'dir': "📁 監視対象ディレクトリ:",
+            'pattern': "🔍 検出パターン:",
+            'active': "📊 アクティブ基準:",
+            'days_within': "日以内",
+            'dormant': "💤 休止中基準:",
+            'days_over': "日以上",
+            'files': "生成されたファイル:",
+            'next_header': "🎉 次のステップ:",
+            'next_prompt': "Claude Codeで以下のように指示してください：",
+            'next_command': '  「プロジェクト状況を更新して」',
+            'next_note': "これで、すべてのプロジェクト情報が収集されます。"
+        }
+    }
+    m = msgs[language]
+
     print("\n" + "=" * 70)
-    print("✅ セットアップが完了しました！")
+    print(m['header'])
     print("=" * 70)
-    print("\n📁 監視対象ディレクトリ:", directory)
-    print("🔍 検出パターン:", pattern)
-    print("📊 アクティブ基準:", f"{active_days}日以内")
-    print("💤 休止中基準:", f"{inactive_days}日以上")
-    print("\n生成されたファイル:")
+    print(f"\n{m['dir']} {directory}")
+    print(f"{m['pattern']} {pattern}")
+    print(f"{m['active']} {active_days} {m['days_within']}")
+    print(f"{m['dormant']} {inactive_days} {m['days_over']}")
+    print(f"\n{m['files']}")
     print("  - config.yml")
     if Path("PROJECT_STATUS.md").exists():
-        print("  - PROJECT_STATUS.md（初期版）")
+        print("  - PROJECT_STATUS.md")
     print("\n" + "-" * 70)
-    print("🎉 次のステップ:")
+    print(m['next_header'])
     print("-" * 70)
-    print("\nClaude Codeで以下のように指示してください：")
-    print('  「プロジェクト状況を更新して」')
-    print("\nこれで、すべてのプロジェクト情報が収集されます。\n")
+    print(f"\n{m['next_prompt']}")
+    print(m['next_command'])
+    print(f"\n{m['next_note']}\n")
 
 if __name__ == "__main__":
     try:
         main()
     except KeyboardInterrupt:
-        print("\n\n❌ セットアップが中断されました。")
+        print("\n\n❌ Setup interrupted.")
         sys.exit(1)
     except Exception as e:
-        print(f"\n\n❌ エラーが発生しました: {e}")
+        print(f"\n\n❌ Error occurred: {e}")
         import traceback
         traceback.print_exc()
         sys.exit(1)


### PR DESCRIPTION
- Add language setting (en/ja) to config.example.yml
- Update .claude/commands/*.md to English with translation logic
- Update commands/*.md to English with translation logic
- Add language selection to onboarding.py setup wizard
- Update guide-en.md with language settings documentation
- Deprecate guide-ja.md in favor of dynamic translation

When settings.language is not "en", Claude will dynamically translate all output to the configured language.