### PR TITLE
fix: add required owner field to marketplace.json and update install docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,10 @@
 {
   "name": "signalcompose-ypm",
   "description": "Signal Compose YPM - Multi-project progress tracking",
+  "owner": {
+    "name": "Hiroshi Yamato",
+    "email": "info@signalcompose.com"
+  },
   "plugins": [
     {
       "name": "ypm",

--- a/README.md
+++ b/README.md
@@ -26,8 +26,11 @@ YPM is installed as a Claude Code plugin, making it accessible from **any direct
 ### Step 1: Install the Plugin
 
 ```bash
-# In Claude Code, run:
-/install signalcompose/YPM
+# In Claude Code, first add the marketplace:
+/plugin marketplace add signalcompose/YPM
+
+# Then install the plugin:
+/plugin install ypm
 ```
 
 ### Step 2: Initial Setup


### PR DESCRIPTION
## Summary
- marketplace.jsonに必須のownerフィールドを追加
- README.mdのプラグインインストール手順を正しいコマンドに修正

## Changes
- `owner`フィールド追加（スキーマ必須項目）
- `/install` → `/plugin marketplace add` + `/plugin install`

## Test plan
- [ ] `/plugin marketplace add signalcompose/YPM`でエラーが出ないことを確認
- [ ] `/plugin install ypm`でプラグインがインストールされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)