### PR TITLE
docs: use lowercase in marketplace add command

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ YPM is installed as a Claude Code plugin, making it accessible from **any direct
 
 ```bash
 # In Claude Code, first add the marketplace:
-/plugin marketplace add signalcompose/YPM
+/plugin marketplace add signalcompose/ypm
 
 # Then install the plugin:
 /plugin install ypm


### PR DESCRIPTION
## Summary
- マーケットプレイス追加コマンドを小文字に変更 (`signalcompose/YPM` → `signalcompose/ypm`)

## Reason
macOSのcase-insensitiveファイルシステム（APFS）で、大文字のリポジトリ名を使用すると`signalcompose-YPM`から`signalcompose-ypm`へのリネーム時にエラーが発生する。

## Test plan
- [ ] `/plugin marketplace add signalcompose/ypm` で正常に登録できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)