### PR TITLE
fix: use lowercase repo name in marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "ypm",
       "source": {
         "source": "github",
-        "repo": "signalcompose/YPM"
+        "repo": "signalcompose/ypm"
       },
       "description": "Multi-project progress tracking system",
       "category": "productivity",


### PR DESCRIPTION
## Summary
- `marketplace.json` のプラグインソースリポジトリ名を小文字に変更

## Reason
README.mdの修正に加え、`marketplace.json`内の`plugins[].source.repo`も小文字にする必要があった。
これにより、プラグインインストール時のcase-insensitive問題を完全に解決。

## Test plan
- [ ] `/plugin marketplace update signalcompose-ypm` でマーケットプレイスを更新
- [ ] `/plugin` でypmプラグインをインストールできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)