### PR TITLE
fix: use local source for plugin in same repository

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,10 +8,7 @@
   "plugins": [
     {
       "name": "ypm",
-      "source": {
-        "source": "github",
-        "repo": "signalcompose/ypm"
-      },
+      "source": "./",
       "description": "Multi-project progress tracking system",
       "category": "productivity",
       "tags": ["project-management", "git", "workflow"]


### PR DESCRIPTION
## Summary
- `marketplace.json` の `source` を `"./"` に変更

## Problem
マーケットプレイスとプラグインが同じリポジトリにある場合、`source: { source: "github", repo: "..." }` を使用すると、「already installed」と表示されインストールできない。

## Solution
anthropic-agent-skills マーケットプレイスと同様に、`source: "./"` を使用してローカルパスを参照するように変更。

## References
- Claude Code公式ドキュメント: plugin-marketplaces.md
- 参考実装: anthropic-agent-skills

## Test plan
- [ ] `/plugin marketplace update signalcompose-ypm` でマーケットプレイスを更新
- [ ] `/plugin` でypmプラグインがインストール可能になることを確認
- [ ] `/plugin install ypm@signalcompose-ypm` でインストール成功を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)