### PR TITLE
chore: Add CODEOWNERS for repository security

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,20 @@
+# CODEOWNERS
+# 重要ファイルの変更には承認が必要
+
+# グローバル設定
+* @dropcontrol
+
+# GitHub設定ファイル
+/.github/ @dropcontrol
+
+# CI/CD設定
+/.github/workflows/ @dropcontrol
+
+# 依存関係
+/requirements.txt @dropcontrol
+
+# セキュリティ設定
+/.gitignore @dropcontrol
+
+# プラグイン設定
+/.claude-plugin/ @dropcontrol


### PR DESCRIPTION
## Summary
- 小規模OSSとしてCODEOWNERSを追加
- 全ファイルのオーナーを@dropcontrolに設定
- GitHub設定、CI/CD、依存関係、プラグイン設定を保護

## Test plan
- [ ] CODEOWNERSが正しく認識されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)