### PR TITLE
docs: fix remaining YPM URL references to ypm

### DIFF
--- a/docs/development/global-export-system.md
+++ b/docs/development/global-export-system.md
@@ -342,7 +342,7 @@ fi
 
 ```bash
 # 正しい方法
-gh pr create -R signalcompose/YPM-yamato --base develop --head feature/xxx
+gh pr create -R signalcompose/ypm-yamato --base develop --head feature/xxx
 
 # 間違った方法（upstreamに誤爆する可能性）
 gh pr create --base develop --head feature/xxx
@@ -401,5 +401,5 @@ export:
 ## 関連ドキュメント
 
 - [Private-to-Public Strategy](../research/private-to-public-strategy.md)
-- [Issue #4](https://github.com/signalcompose/YPM/issues/4) - Auto-merge機能追加
-- [Issue #45](https://github.com/signalcompose/YPM/pull/45) - グローバルエクスポートシステム実装
+- [Issue #4](https://github.com/signalcompose/ypm/issues/4) - Auto-merge機能追加
+- [Issue #45](https://github.com/signalcompose/ypm/pull/45) - グローバルエクスポートシステム実装

--- a/docs/guide-en.md
+++ b/docs/guide-en.md
@@ -552,7 +552,7 @@ monitor:
 
 ### Q: Can I use this on another machine?
 
-**A**: Yes. Install YPM using `/install signalcompose/YPM`, then run `/ypm:setup` to configure your environment. You can also copy your `~/.ypm/config.yml` to the new machine.
+**A**: Yes. Install YPM using `/plugin marketplace add signalcompose/ypm`, then run `/ypm:setup` to configure your environment. You can also copy your `~/.ypm/config.yml` to the new machine.
 
 ---
 
@@ -594,7 +594,7 @@ Contributions to YPM are welcome!
 
 ### Bug Reports & Feature Requests
 
-- Report via [GitHub Issues](https://github.com/signalcompose/YPM/issues)
+- Report via [GitHub Issues](https://github.com/signalcompose/ypm/issues)
 
 ### Pull Requests
 

--- a/docs/research/private-to-public-strategy.md
+++ b/docs/research/private-to-public-strategy.md
@@ -220,7 +220,7 @@ return message
 set -e
 
 PRIVATE_REPO="/Users/yamato/Src/proj_YPM/YPM-yamato"
-PUBLIC_REPO_URL="https://github.com/signalcompose/YPM.git"
+PUBLIC_REPO_URL="https://github.com/signalcompose/ypm.git"
 EXPORT_DIR="/tmp/ypm-public-export-$(date +%s)"
 
 echo "🔍 Exporting YPM to public repository..."
@@ -253,7 +253,7 @@ git remote add public "$PUBLIC_REPO_URL"
 git push public develop:main --force
 
 echo "✅ Export completed!"
-echo "⚠️  Verify: https://github.com/signalcompose/YPM"
+echo "⚠️  Verify: https://github.com/signalcompose/ypm"
 ```
 
 ### 実行手順
@@ -293,7 +293,7 @@ git show  # 最新コミット詳細確認
 cd ~/Src/proj_YPM/YPM-yamato
 
 # Public repoをremoteに追加（初回のみ）
-git remote add public https://github.com/signalcompose/YPM.git
+git remote add public https://github.com/signalcompose/ypm.git
 
 # Public repoの最新情報を取得
 git fetch public
@@ -347,7 +347,7 @@ git push origin develop
 ```bash
 # GitHub UIでPR #XXXをマージ
 # または gh CLIで
-gh pr merge 10 --repo signalcompose/YPM --merge
+gh pr merge 10 --repo signalcompose/ypm --merge
 ```
 
 ### フロー図

--- a/templates/scripts/export-to-community.sh
+++ b/templates/scripts/export-to-community.sh
@@ -454,7 +454,7 @@ print_success "Feature branch pushed: $FEATURE_BRANCH"
 
 print_info "📝 Creating pull request..."
 
-# Extract repository name from URL (e.g., signalcompose/YPM)
+# Extract repository name from URL (e.g., signalcompose/ypm)
 REPO_NAME=$(echo "$PUBLIC_REPO_URL" | sed -E 's/.*github\.com[:/](.*)\.git/\1/')
 
 # Get the last commit SHA from public repo


### PR DESCRIPTION
## Summary

Updated all remaining references from uppercase `YPM` to lowercase `ypm` to maintain consistency after repository rename.

## Changes

### Documentation Updates
- **docs/guide-en.md** (2 changes):
  - FAQ installation command: `/install signalcompose/YPM` → `/plugin marketplace add signalcompose/ypm`
  - Issues URL: Updated to lowercase
  
- **docs/research/private-to-public-strategy.md** (4 changes):
  - All example URLs updated to `signalcompose/ypm`
  
- **docs/development/global-export-system.md** (3 changes):
  - PR creation example: `signalcompose/YPM-yamato` → `signalcompose/ypm-yamato`
  - Issue/PR URLs updated
  
- **templates/scripts/export-to-community.sh** (1 change):
  - Comment example updated for consistency

## Impact

- ✅ All URLs now consistently use lowercase `ypm`
- ✅ Aligns with actual repository name: `signalcompose/ypm`
- ✅ Improves documentation accuracy
- ✅ No broken links (GitHub URLs are case-insensitive)

## Related

- Follows up on PR #32 (post-rename cleanup)
- Completes repository rename documentation updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)